### PR TITLE
ci: Enable POSTGIS extension by default

### DIFF
--- a/deployment/values.dev.yaml
+++ b/deployment/values.dev.yaml
@@ -31,6 +31,13 @@ db:
     initialDelaySeconds: 3
   persistence:
     enabled: false
+  config:
+    # Enable the PostGIS extension on deployment
+    postgis.sql: |
+      BEGIN;
+        -- Create postgis extension
+        CREATE EXTENSION IF NOT EXISTS postgis SCHEMA extensions;
+      COMMIT;
 
 studio:
   imagePullSecrets:


### PR DESCRIPTION
This PR enables postgis by default for creation of Tables with geometries.