### PR TITLE
feat: add tables user_roles, role_permissions and cluster_roles

### DIFF
--- a/src/support_sphere_py/src/support_sphere/models/enums/__init__.py
+++ b/src/support_sphere_py/src/support_sphere/models/enums/__init__.py
@@ -1,0 +1,6 @@
+from support_sphere.models.enums.app_permissions import AppPermissions
+from support_sphere.models.enums.app_roles import AppRoles
+from support_sphere.models.enums.operational_status import OperationalStatus
+
+
+__all__ = ['AppPermissions', 'AppRoles', 'OperationalStatus']

--- a/src/support_sphere_py/src/support_sphere/models/enums/app_permissions.py
+++ b/src/support_sphere_py/src/support_sphere/models/enums/app_permissions.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class AppPermissions(Enum):
+    OPERATIONAL_EVENT_READ = "operational_event.read"
+    OPERATIONAL_EVENT_CREATE = "operational_event.create"

--- a/src/support_sphere_py/src/support_sphere/models/enums/app_roles.py
+++ b/src/support_sphere_py/src/support_sphere/models/enums/app_roles.py
@@ -1,0 +1,12 @@
+from enum import Enum
+
+
+class AppRoles(Enum):
+    MEMBER = ("member", "A regular community member")
+    CAPTAIN = ("captain", "A cluster captain of the community")
+    MANAGER = ("manager", "A LEAP committee member")
+    ADMIN = ("admin", "A University of Washington Team member")
+
+    def __init__(self, role, description):
+        self.role = role
+        self.description = description

--- a/src/support_sphere_py/src/support_sphere/models/enums/operational_status.py
+++ b/src/support_sphere_py/src/support_sphere/models/enums/operational_status.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class OperationalStatus(Enum):
+    EMERGENCY = ("emergency", "Total Emergency Mode")
+    TEST = ("test", "Test Emergency Mode")
+    NORMAL = ("normal", "We're all good capn'")
+
+    def __init__(self, status, description):
+        self.status = status
+        self.description = description

--- a/src/support_sphere_py/src/support_sphere/models/enums/operational_status.py
+++ b/src/support_sphere_py/src/support_sphere/models/enums/operational_status.py
@@ -4,7 +4,7 @@ from enum import Enum
 class OperationalStatus(Enum):
     EMERGENCY = ("emergency", "Total Emergency Mode")
     TEST = ("test", "Test Emergency Mode")
-    NORMAL = ("normal", "We're all good capn'")
+    NORMAL = ("normal", "Normal Operation Mode")
 
     def __init__(self, status, description):
         self.status = status

--- a/src/support_sphere_py/src/support_sphere/models/public/__init__.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/__init__.py
@@ -4,10 +4,11 @@ from support_sphere.models.public.cluster import Cluster
 from support_sphere.models.public.people_group import PeopleGroup
 from support_sphere.models.public.household import Household
 from support_sphere.models.public.user_role import UserRole
-from support_sphere.models.public.cluster_role import ClusterRole
+from support_sphere.models.public.user_captain_cluster import UserCaptainCluster
 from support_sphere.models.public.role_permission import RolePermission
 
 
 # New models created should be exposed by adding to __all__. This is used by SQLModel.metadata
 # https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#sqlmodel-metadata-order-matters
-__all__ = ['UserProfile', 'People', 'Cluster', 'PeopleGroup', 'Household', 'UserRole', 'ClusterRole', 'RolePermission']
+__all__ = ['UserProfile', 'People', 'Cluster', 'PeopleGroup', 'Household', 'UserRole', 'UserCaptainCluster',
+           'RolePermission']

--- a/src/support_sphere_py/src/support_sphere/models/public/__init__.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/__init__.py
@@ -3,8 +3,11 @@ from support_sphere.models.public.people import People
 from support_sphere.models.public.cluster import Cluster
 from support_sphere.models.public.people_group import PeopleGroup
 from support_sphere.models.public.household import Household
+from support_sphere.models.public.user_role import UserRole
+from support_sphere.models.public.cluster_role import ClusterRole
+from support_sphere.models.public.role_permission import RolePermission
 
 
 # New models created should be exposed by adding to __all__. This is used by SQLModel.metadata
 # https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#sqlmodel-metadata-order-matters
-__all__ = ['UserProfile', 'People', 'Cluster', 'PeopleGroup', 'Household']
+__all__ = ['UserProfile', 'People', 'Cluster', 'PeopleGroup', 'Household', 'UserRole', 'ClusterRole', 'RolePermission']

--- a/src/support_sphere_py/src/support_sphere/models/public/cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/cluster.py
@@ -24,6 +24,10 @@ class Cluster(BasePublicSchemaModel, table=True):
         A list of `Household` entries associated with this cluster, representing a one-to-many relationship
         where a  single `Cluster` can have multiple households. The relationship is configured with `back_populates`
         to match the `cluster` attribute in the `Household` model, and cascade delete is disabled.
+    cluster_roles : list[ClusterRole]
+        A list of `ClusterRole` entries associated with this cluster, representing a one-to-many relationship
+        where a  single `Cluster` can have multiple cluster_roles. The relationship is configured with `back_populates`
+        to match the `cluster` attribute in the `ClusterRole` model, and cascade delete is disabled.
 
     Notes
     -----
@@ -41,3 +45,4 @@ class Cluster(BasePublicSchemaModel, table=True):
     geom: Geometry|None = Field(sa_type=Geometry(geometry_type="POLYGON"), nullable=True)
 
     households: list["Household"] = Relationship(back_populates="cluster", cascade_delete=False)
+    cluster_roles: list["ClusterRole"] = Relationship(back_populates="cluster", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/cluster.py
@@ -45,4 +45,4 @@ class Cluster(BasePublicSchemaModel, table=True):
     geom: Geometry|None = Field(sa_type=Geometry(geometry_type="POLYGON"), nullable=True)
 
     households: list["Household"] = Relationship(back_populates="cluster", cascade_delete=False)
-    user_captain_clusters: list["UserCaptainCluster"] = Relationship(back_populates="cluster", cascade_delete=False)
+    user_captains: list["UserCaptainCluster"] = Relationship(back_populates="cluster", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/cluster.py
@@ -24,7 +24,7 @@ class Cluster(BasePublicSchemaModel, table=True):
         A list of `Household` entries associated with this cluster, representing a one-to-many relationship
         where a  single `Cluster` can have multiple households. The relationship is configured with `back_populates`
         to match the `cluster` attribute in the `Household` model, and cascade delete is disabled.
-    user_captains : list[ClusterRole]
+    user_captains : list[UserCaptainCluster]
         A list of `UserCaptainCluster` entries associated with this cluster, representing a one-to-many relationship
         where a  single `Cluster` can have multiple captains. The relationship is configured with `back_populates`
         to match the `cluster` attribute in the `UserCaptainCluster` model, and cascade delete is disabled.

--- a/src/support_sphere_py/src/support_sphere/models/public/cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/cluster.py
@@ -24,7 +24,7 @@ class Cluster(BasePublicSchemaModel, table=True):
         A list of `Household` entries associated with this cluster, representing a one-to-many relationship
         where a  single `Cluster` can have multiple households. The relationship is configured with `back_populates`
         to match the `cluster` attribute in the `Household` model, and cascade delete is disabled.
-    user_captain_clusters : list[ClusterRole]
+    user_captains : list[ClusterRole]
         A list of `UserCaptainCluster` entries associated with this cluster, representing a one-to-many relationship
         where a  single `Cluster` can have multiple captains. The relationship is configured with `back_populates`
         to match the `cluster` attribute in the `UserCaptainCluster` model, and cascade delete is disabled.

--- a/src/support_sphere_py/src/support_sphere/models/public/cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/cluster.py
@@ -24,10 +24,10 @@ class Cluster(BasePublicSchemaModel, table=True):
         A list of `Household` entries associated with this cluster, representing a one-to-many relationship
         where a  single `Cluster` can have multiple households. The relationship is configured with `back_populates`
         to match the `cluster` attribute in the `Household` model, and cascade delete is disabled.
-    cluster_roles : list[ClusterRole]
-        A list of `ClusterRole` entries associated with this cluster, representing a one-to-many relationship
-        where a  single `Cluster` can have multiple cluster_roles. The relationship is configured with `back_populates`
-        to match the `cluster` attribute in the `ClusterRole` model, and cascade delete is disabled.
+    user_captain_clusters : list[ClusterRole]
+        A list of `UserCaptainCluster` entries associated with this cluster, representing a one-to-many relationship
+        where a  single `Cluster` can have multiple captains. The relationship is configured with `back_populates`
+        to match the `cluster` attribute in the `UserCaptainCluster` model, and cascade delete is disabled.
 
     Notes
     -----
@@ -45,4 +45,4 @@ class Cluster(BasePublicSchemaModel, table=True):
     geom: Geometry|None = Field(sa_type=Geometry(geometry_type="POLYGON"), nullable=True)
 
     households: list["Household"] = Relationship(back_populates="cluster", cascade_delete=False)
-    cluster_roles: list["ClusterRole"] = Relationship(back_populates="cluster", cascade_delete=False)
+    user_captain_clusters: list["UserCaptainCluster"] = Relationship(back_populates="cluster", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/cluster_role.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/cluster_role.py
@@ -1,0 +1,42 @@
+import uuid
+from typing import Optional
+
+from support_sphere.models.base import BasePublicSchemaModel
+from sqlmodel import Field, Relationship
+
+
+class ClusterRole(BasePublicSchemaModel, table=True):
+    """
+    Represents the association between clusters and role permissions in the 'public' schema under the 'role_clusters' table.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        The unique identifier for the cluster role entry, generated automatically using UUID.
+    cluster_id : int
+        The identifier for the cluster that this role is associated with, representing a foreign key
+        to the 'public.clusters' table.
+    user_role_id : uuid.UUID
+        The identifier for the user_role associated with this cluster, representing a foreign key
+        to the 'public.user_roles' table.
+    cluster : Optional[Cluster]
+        The associated `Cluster` object, representing a many-to-one relationship between `ClusterRole`
+        and `Cluster`. Cascading delete is disabled.
+    user_role : Optional[UserRole]
+        The associated `UserRole` object, representing a many-to-one relationship between `ClusterRole`
+        and `UserRole`. Cascading delete is disabled.
+
+    Notes
+    -----
+    - The `cluster_id` and `role_permission_id` fields create foreign key constraints to the 'clusters' and
+      'user_roles' tables respectively.
+    - The relationships with `Cluster` and `RolePermission` are designed as many-to-one relationships.
+    """
+    __tablename__ = "cluster_roles"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    cluster_id: int = Field(foreign_key="public.clusters.id", nullable=False)
+    user_role_id: uuid.UUID = Field(foreign_key="public.user_roles.id", nullable=False)
+
+    cluster: Optional["Cluster"] = Relationship(back_populates="cluster_roles", cascade_delete=False)
+    user_role: Optional["UserRole"] = Relationship(back_populates="cluster_roles", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/role_permission.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/role_permission.py
@@ -1,0 +1,31 @@
+import uuid
+from support_sphere.models.base import BasePublicSchemaModel
+from sqlmodel import Field, Relationship
+from sqlalchemy import Enum
+
+from support_sphere.models.enums import AppRoles, AppPermissions
+
+
+class RolePermission(BasePublicSchemaModel, table=True):
+    """
+    Represents the permissions assigned to roles in the 'public' schema under the 'role_permissions' table.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        The unique identifier for the role permission entry, generated automatically using UUID.
+    role : AppRoles
+        The role to which the permission is assigned, represented as an enum (AppRoles). This field cannot be null.
+    permission : AppPermissions
+        The permission granted to the role, represented as an enum (AppPermissions). This field cannot be null.
+
+    Notes
+    -----
+    - The `role` and `permission` fields use the SQLAlchemy `Enum` type to store enum values for roles and permissions.
+    - The relationship between `RolePermission` and `ClusterRole` is designed as a one-to-many relationship.
+    """
+    __tablename__ = "role_permissions"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    role: AppRoles = Field(sa_type=Enum(AppRoles), nullable=False)
+    permission: AppPermissions = Field(sa_type=Enum(AppPermissions), nullable=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/user_captain_cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_captain_cluster.py
@@ -5,9 +5,10 @@ from support_sphere.models.base import BasePublicSchemaModel
 from sqlmodel import Field, Relationship
 
 
-class ClusterRole(BasePublicSchemaModel, table=True):
+class UserCaptainCluster(BasePublicSchemaModel, table=True):
     """
-    Represents the association between clusters and role permissions in the 'public' schema under the 'role_clusters' table.
+    Represents the association between clusters and the captain role in the 'public' schema under the 'user_captain_clusters'
+     table.
 
     Attributes
     ----------
@@ -20,10 +21,10 @@ class ClusterRole(BasePublicSchemaModel, table=True):
         The identifier for the user_role associated with this cluster, representing a foreign key
         to the 'public.user_roles' table.
     cluster : Optional[Cluster]
-        The associated `Cluster` object, representing a many-to-one relationship between `ClusterRole`
+        The associated `Cluster` object, representing a many-to-one relationship between `UserCaptainCluster`
         and `Cluster`. Cascading delete is disabled.
     user_role : Optional[UserRole]
-        The associated `UserRole` object, representing a many-to-one relationship between `ClusterRole`
+        The associated `UserRole` object, representing a many-to-one relationship between `UserCaptainCluster`
         and `UserRole`. Cascading delete is disabled.
 
     Notes
@@ -32,11 +33,11 @@ class ClusterRole(BasePublicSchemaModel, table=True):
       'user_roles' tables respectively.
     - The relationships with `Cluster` and `RolePermission` are designed as many-to-one relationships.
     """
-    __tablename__ = "cluster_roles"
+    __tablename__ = "user_captain_clusters"
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     cluster_id: int = Field(foreign_key="public.clusters.id", nullable=False)
     user_role_id: uuid.UUID = Field(foreign_key="public.user_roles.id", nullable=False)
 
-    cluster: Optional["Cluster"] = Relationship(back_populates="cluster_roles", cascade_delete=False)
-    user_role: Optional["UserRole"] = Relationship(back_populates="cluster_roles", cascade_delete=False)
+    cluster: Optional["Cluster"] = Relationship(back_populates="user_captain_clusters", cascade_delete=False)
+    user_role: Optional["UserRole"] = Relationship(back_populates="user_captain_clusters", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/user_captain_cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_captain_cluster.py
@@ -39,5 +39,5 @@ class UserCaptainCluster(BasePublicSchemaModel, table=True):
     cluster_id: int = Field(foreign_key="public.clusters.id", nullable=False)
     user_role_id: uuid.UUID = Field(foreign_key="public.user_roles.id", nullable=False)
 
-    cluster: Optional["Cluster"] = Relationship(back_populates="user_captain_clusters", cascade_delete=False)
-    user_role: Optional["UserRole"] = Relationship(back_populates="user_captain_clusters", cascade_delete=False)
+    cluster: Optional["Cluster"] = Relationship(back_populates="user_captains", cascade_delete=False)
+    user_role: Optional["UserRole"] = Relationship(back_populates="user_captains", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/user_profile.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_profile.py
@@ -21,6 +21,10 @@ class UserProfile(BasePublicSchemaModel, table=True):
         A relationship to the `User` model (from the `auth.users` table), with back_populates set
         to "user_profile", establishing a one-to-one connection between UserProfile and User.
         This is NOT a column in the table but represents relationship only.
+    user_roles: list[UserRole]
+        A list of `UserRole` objects associated with this user_profile. Represents a one-to-many relationship where
+        each `user_profile` can have multiple `UserRole` entities. The relationship is configured with `back_populates`
+        to match the `user_profile` attribute in the `UserRole` model, and cascading delete is disabled.
 
     Notes
     -----
@@ -36,4 +40,5 @@ class UserProfile(BasePublicSchemaModel, table=True):
     user: User = Relationship(back_populates="user_profile")
     person_details: Optional["People"] = Relationship(back_populates="user_profile",
                                                       cascade_delete=False, sa_relationship_kwargs={"uselist": False})
+    user_roles: list["UserRole"] = Relationship(back_populates="user_profile", cascade_delete=False)
 

--- a/src/support_sphere_py/src/support_sphere/models/public/user_role.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_role.py
@@ -1,0 +1,47 @@
+import uuid
+from typing import Optional
+
+from support_sphere.models.base import BasePublicSchemaModel
+from sqlmodel import Field, Relationship
+
+from support_sphere.models.enums import AppRoles
+from sqlalchemy import Enum
+
+
+class UserRole(BasePublicSchemaModel, table=True):
+    """
+    Represents the roles assigned to user profiles in the 'public' schema under the 'user_roles' table.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        The unique identifier for the user role, generated automatically using UUID.
+    user_profile_id : uuid.UUID
+        The unique identifier of the associated user profile from the 'public.user_profiles' table.
+        This is a foreign key and is unique for each role.
+    role : AppRoles
+        The role assigned to the user profile, represented as an enum (AppRoles). This field cannot be null.
+    cluster_roles : list[ClusterRole]
+        A list of `ClusterRole` entries associated with this user_role, representing a one-to-many relationship
+        where a  single `UserRole` can have multiple cluster_roles. The relationship is configured with `back_populates`
+        to match the `user_role` attribute in the `ClusterRole` model, and cascade delete is disabled.
+    user_profile : Optional[UserProfile]
+        The associated `UserProfile` object for this role. It represents a one-to-one relationship where
+        each `UserRole` is linked to a single `UserProfile`. The relationship uses `back_populates` to match
+        the `user_role` attribute in the `UserProfile` model. Cascading delete is disabled.
+
+    Notes
+    -----
+    - The `role` field uses the SQLAlchemy `Enum` type to store role data, mapped from the `AppRoles` enum.
+    - The relationship between `UserRole` and `UserProfile` is designed as a one-to-one relationship.
+    """
+    __tablename__ = "user_roles"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    user_profile_id: uuid.UUID | None = Field(foreign_key="public.user_profiles.id", nullable=False)
+    role: AppRoles = Field(sa_type=Enum(AppRoles), nullable=False)
+    cluster_roles: list["ClusterRole"] = Relationship(back_populates="user_role", cascade_delete=False)
+
+    user_profile: Optional["UserProfile"] = Relationship(
+        back_populates="user_roles", cascade_delete=False,
+    )

--- a/src/support_sphere_py/src/support_sphere/models/public/user_role.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_role.py
@@ -21,10 +21,10 @@ class UserRole(BasePublicSchemaModel, table=True):
         This is a foreign key and is unique for each role.
     role : AppRoles
         The role assigned to the user profile, represented as an enum (AppRoles). This field cannot be null.
-    cluster_roles : list[ClusterRole]
-        A list of `ClusterRole` entries associated with this user_role, representing a one-to-many relationship
-        where a  single `UserRole` can have multiple cluster_roles. The relationship is configured with `back_populates`
-        to match the `user_role` attribute in the `ClusterRole` model, and cascade delete is disabled.
+    user_captain_clusters : list[ClusterRole]
+        A list of `UserCaptainCluster` entries associated with this user_role, representing a one-to-many relationship
+        where a  single `UserRole` can be captain of multiple clusters. The relationship is configured with
+        `back_populates` to match the `user_role` attribute in the `UserCaptainCluster` model. Cascade delete disabled.
     user_profile : Optional[UserProfile]
         The associated `UserProfile` object for this role. It represents a one-to-one relationship where
         each `UserRole` is linked to a single `UserProfile`. The relationship uses `back_populates` to match
@@ -40,7 +40,7 @@ class UserRole(BasePublicSchemaModel, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     user_profile_id: uuid.UUID | None = Field(foreign_key="public.user_profiles.id", nullable=False)
     role: AppRoles = Field(sa_type=Enum(AppRoles), nullable=False)
-    cluster_roles: list["ClusterRole"] = Relationship(back_populates="user_role", cascade_delete=False)
+    user_captain_clusters: list["UserCaptainCluster"] = Relationship(back_populates="user_role", cascade_delete=False)
 
     user_profile: Optional["UserProfile"] = Relationship(
         back_populates="user_roles", cascade_delete=False,

--- a/src/support_sphere_py/src/support_sphere/models/public/user_role.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_role.py
@@ -21,7 +21,7 @@ class UserRole(BasePublicSchemaModel, table=True):
         This is a foreign key and is unique for each role.
     role : AppRoles
         The role assigned to the user profile, represented as an enum (AppRoles). This field cannot be null.
-    user_captain_clusters : list[ClusterRole]
+    user_captains : list[ClusterRole]
         A list of `UserCaptainCluster` entries associated with this user_role, representing a one-to-many relationship
         where a  single `UserRole` can be captain of multiple clusters. The relationship is configured with
         `back_populates` to match the `user_role` attribute in the `UserCaptainCluster` model. Cascade delete disabled.

--- a/src/support_sphere_py/src/support_sphere/models/public/user_role.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_role.py
@@ -40,7 +40,7 @@ class UserRole(BasePublicSchemaModel, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     user_profile_id: uuid.UUID | None = Field(foreign_key="public.user_profiles.id", nullable=False)
     role: AppRoles = Field(sa_type=Enum(AppRoles), nullable=False)
-    user_captain_clusters: list["UserCaptainCluster"] = Relationship(back_populates="user_role", cascade_delete=False)
+    user_captains: list["UserCaptainCluster"] = Relationship(back_populates="user_role", cascade_delete=False)
 
     user_profile: Optional["UserProfile"] = Relationship(
         back_populates="user_roles", cascade_delete=False,

--- a/src/support_sphere_py/src/support_sphere/models/public/user_role.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_role.py
@@ -21,7 +21,7 @@ class UserRole(BasePublicSchemaModel, table=True):
         This is a foreign key and is unique for each role.
     role : AppRoles
         The role assigned to the user profile, represented as an enum (AppRoles). This field cannot be null.
-    user_captains : list[ClusterRole]
+    user_captains : list[UserCaptainCluster]
         A list of `UserCaptainCluster` entries associated with this user_role, representing a one-to-many relationship
         where a  single `UserRole` can be captain of multiple clusters. The relationship is configured with
         `back_populates` to match the `user_role` attribute in the `UserCaptainCluster` model. Cascade delete disabled.

--- a/src/support_sphere_py/tests/resources/scripts/update_db_sample_data.py
+++ b/src/support_sphere_py/tests/resources/scripts/update_db_sample_data.py
@@ -3,11 +3,14 @@ import yaml
 from pathlib import Path
 from supabase import create_client, Client
 
-from support_sphere.models.public import UserProfile, People, Cluster, PeopleGroup, Household
+from support_sphere.models.public import (UserProfile, People, Cluster, PeopleGroup, Household,
+                                          RolePermission, UserRole, ClusterRole)
 from support_sphere.models.auth import User
 from support_sphere.repositories.auth import UserRepository
 from support_sphere.repositories.base_repository import BaseRepository
 from support_sphere.repositories.public import UserProfileRepository, PeopleRepository
+
+from support_sphere.models.enums import AppRoles, AppPermissions
 
 import logging
 
@@ -88,6 +91,23 @@ def authenticate_user_signup_signin_signout_via_supabase(supabase: Client):
     supabase.auth.sign_out()
 
 
+def update_user_permissions_roles_by_cluster():
+    role_1 = RolePermission(role=AppRoles.ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_READ)
+    role_2 = RolePermission(role=AppRoles.ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_CREATE)
+    role_3 = RolePermission(role=AppRoles.CAPTAIN, permission=AppPermissions.OPERATIONAL_EVENT_READ)
+
+    BaseRepository.add(role_1)
+    BaseRepository.add(role_2)
+    BaseRepository.add(role_3)
+
+    user_profile = UserProfileRepository.find_by_username('adamabacus')
+    user_role = UserRole(user_profile=user_profile, role=AppRoles.CAPTAIN)
+    BaseRepository.add(user_role)
+
+    cluster_role = ClusterRole(cluster_id=1, user_role=user_role)
+    BaseRepository.add(cluster_role)
+
+
 if __name__ == '__main__':
 
     supabase = get_supabase_client()
@@ -95,5 +115,6 @@ if __name__ == '__main__':
     authenticate_user_signup_signin_signout_via_supabase(supabase)
     populate_cluster_and_household_details()
     populate_user_details(supabase)
+    update_user_permissions_roles_by_cluster()
     
 

--- a/src/support_sphere_py/tests/resources/scripts/update_db_sample_data.py
+++ b/src/support_sphere_py/tests/resources/scripts/update_db_sample_data.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from supabase import create_client, Client
 
 from support_sphere.models.public import (UserProfile, People, Cluster, PeopleGroup, Household,
-                                          RolePermission, UserRole, ClusterRole)
+                                          RolePermission, UserRole, UserCaptainCluster)
 from support_sphere.models.auth import User
 from support_sphere.repositories.auth import UserRepository
 from support_sphere.repositories.base_repository import BaseRepository
@@ -104,7 +104,7 @@ def update_user_permissions_roles_by_cluster():
     user_role = UserRole(user_profile=user_profile, role=AppRoles.CAPTAIN)
     BaseRepository.add(user_role)
 
-    cluster_role = ClusterRole(cluster_id=1, user_role=user_role)
+    cluster_role = UserCaptainCluster(cluster_id=1, user_role=user_role)
     BaseRepository.add(cluster_role)
 
 


### PR DESCRIPTION
#30 

- [x] add user_roles, cluster_roles, role_permissions table - this will be used to set up authZ capabilities
- [x] add enums for app_permissions, operational_status, and app_roles
- [x] update code to populate the local database with sample entries for the above.