### PR TITLE
feat: add role based access control for activating app emergency mode

### DIFF
--- a/deployment/values.dev.yaml
+++ b/deployment/values.dev.yaml
@@ -69,6 +69,8 @@ auth:
     GOTRUE_SMTP_HOST: "smtp.example.com"
     GOTRUE_SMTP_PORT: "587"
     GOTRUE_SMTP_SENDER_NAME: "your-mail@example.com"
+    GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_ENABLED: "true"
+    GOTRUE_HOOK_CUSTOM_ACCESS_TOKEN_URI: "pg-functions://postgres/public/custom_access_token"
 
 rest:
   imagePullSecrets:

--- a/pixi.toml
+++ b/pixi.toml
@@ -19,7 +19,10 @@ pip = "*"
 support-sphere-py = { path = "./src/support_sphere_py", editable = true }
 
 [feature.db.tasks]
-populate-sample-entries = { depends-on = ["populate-user-details"]}
+populate-sample-entries = { depends-on = ["configure-role-based-access", "populate-user-details"]}
+
+[feature.db.tasks.configure-role-based-access]
+cmd = "python3 ./src/support_sphere_py/tests/resources/scripts/role_based_access_control.py"
 
 [feature.db.tasks.populate-user-details]
 cmd = "python3 ./src/support_sphere_py/tests/resources/scripts/update_db_sample_data.py"

--- a/src/support_sphere_py/src/support_sphere/__init__.py
+++ b/src/support_sphere_py/src/support_sphere/__init__.py
@@ -8,6 +8,9 @@ import logging
 from support_sphere.models.auth import *
 from support_sphere.models.public import *
 
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s %(thread)d %(levelname)s %(module)s.%(funcName)s(): %(message)s"
+)
 logger = logging.getLogger(__name__)
 
 username = os.environ.get('DB_USERNAME', 'postgres')

--- a/src/support_sphere_py/src/support_sphere/models/public/__init__.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/__init__.py
@@ -6,9 +6,10 @@ from support_sphere.models.public.household import Household
 from support_sphere.models.public.user_role import UserRole
 from support_sphere.models.public.user_captain_cluster import UserCaptainCluster
 from support_sphere.models.public.role_permission import RolePermission
+from support_sphere.models.public.operational_event import OperationalEvent
 
 
 # New models created should be exposed by adding to __all__. This is used by SQLModel.metadata
 # https://sqlmodel.tiangolo.com/tutorial/create-db-and-table/#sqlmodel-metadata-order-matters
 __all__ = ['UserProfile', 'People', 'Cluster', 'PeopleGroup', 'Household', 'UserRole', 'UserCaptainCluster',
-           'RolePermission']
+           'RolePermission', 'OperationalEvent']

--- a/src/support_sphere_py/src/support_sphere/models/public/cluster.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/cluster.py
@@ -17,6 +17,8 @@ class Cluster(BasePublicSchemaModel, table=True):
         The name of the cluster.
     meeting_place : str, optional
         The location where meetings are held for the cluster.
+    notes : str, optional
+        Additional notes or comments related to the cluster.
     geom : Geometry, optional
         A geometric representation of the cluster area, stored as a POLYGON type. This field uses the SQLAlchemy
         `Geometry` type to store spatial data.
@@ -42,6 +44,7 @@ class Cluster(BasePublicSchemaModel, table=True):
     id: int|None = Field(primary_key=True)
     name: str|None = Field(nullable=True)
     meeting_place: str|None = Field(nullable=True)
+    notes: str | None = Field(nullable=True)
     geom: Geometry|None = Field(sa_type=Geometry(geometry_type="POLYGON"), nullable=True)
 
     households: list["Household"] = Relationship(back_populates="cluster", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/operational_event.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/operational_event.py
@@ -1,0 +1,39 @@
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from support_sphere.models.base import BasePublicSchemaModel
+from sqlmodel import Field, Relationship
+from sqlalchemy import Enum
+
+from support_sphere.models.enums import OperationalStatus
+
+
+class OperationalEvent(BasePublicSchemaModel, table=True):
+    """
+    Represents an operational event in the 'public' schema under the 'operational_events' table.
+
+    Attributes
+    ----------
+    id : uuid.UUID
+        The unique identifier for the operational event, generated automatically using UUID.
+    created_by : uuid.UUID
+        The identifier of the user profile that created the event, representing a foreign key
+        to the 'public.user_profiles' table. This field cannot be null.
+    created_at : datetime
+        The timestamp of when the event was created. This field cannot be null.
+    status : OperationalStatus
+        The status of the operational event, represented as an enum (OperationalStatus). This field cannot be null.
+    user_profile : Optional[UserProfile]
+        The associated `UserProfile` object, representing a many-to-one relationship between `OperationalEvent`
+        and `UserProfile`. Cascading delete is disabled.
+    """
+
+    __tablename__ = "operational_events"
+
+    id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
+    created_by: uuid.UUID | None = Field(foreign_key="public.user_profiles.id", nullable=False)
+    created_at: datetime = Field(nullable=False)
+    status: OperationalStatus = Field(sa_type=Enum(OperationalStatus, name="operational_status"), nullable=False)
+
+    user_profile: Optional["UserProfile"] = Relationship(back_populates="operational_events", cascade_delete=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/role_permission.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/role_permission.py
@@ -27,5 +27,5 @@ class RolePermission(BasePublicSchemaModel, table=True):
     __tablename__ = "role_permissions"
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
-    role: AppRoles = Field(sa_type=Enum(AppRoles), nullable=False)
-    permission: AppPermissions = Field(sa_type=Enum(AppPermissions), nullable=False)
+    role: AppRoles = Field(sa_type=Enum(AppRoles, name="app_roles"), nullable=False)
+    permission: AppPermissions = Field(sa_type=Enum(AppPermissions, name="app_permissions"), nullable=False)

--- a/src/support_sphere_py/src/support_sphere/models/public/user_profile.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_profile.py
@@ -21,9 +21,9 @@ class UserProfile(BasePublicSchemaModel, table=True):
         A relationship to the `User` model (from the `auth.users` table), with back_populates set
         to "user_profile", establishing a one-to-one connection between UserProfile and User.
         This is NOT a column in the table but represents relationship only.
-    user_roles: list[UserRole]
-        A list of `UserRole` objects associated with this user_profile. Represents a one-to-many relationship where
-        each `user_profile` can have multiple `UserRole` entities. The relationship is configured with `back_populates`
+    user_roles: Optional[UserRole]
+        A `UserRole` objects associated with this user_profile. Represents a one-to-one relationship where
+        each `user_profile` can have a single `UserRole` entity. The relationship is configured with `back_populates`
         to match the `user_profile` attribute in the `UserRole` model, and cascading delete is disabled.
 
     Notes
@@ -40,5 +40,6 @@ class UserProfile(BasePublicSchemaModel, table=True):
     user: User = Relationship(back_populates="user_profile")
     person_details: Optional["People"] = Relationship(back_populates="user_profile",
                                                       cascade_delete=False, sa_relationship_kwargs={"uselist": False})
-    user_roles: list["UserRole"] = Relationship(back_populates="user_profile", cascade_delete=False)
+    user_role: Optional["UserRole"] = Relationship(back_populates="user_profile", cascade_delete=False)
+    operational_events: list["OperationalEvent"] = Relationship(back_populates="user_profile", cascade_delete=False)
 

--- a/src/support_sphere_py/src/support_sphere/models/public/user_role.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/user_role.py
@@ -38,10 +38,10 @@ class UserRole(BasePublicSchemaModel, table=True):
     __tablename__ = "user_roles"
 
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
-    user_profile_id: uuid.UUID | None = Field(foreign_key="public.user_profiles.id", nullable=False)
-    role: AppRoles = Field(sa_type=Enum(AppRoles), nullable=False)
+    user_profile_id: uuid.UUID | None = Field(foreign_key="public.user_profiles.id", nullable=False, unique=True)
+    role: AppRoles = Field(sa_type=Enum(AppRoles, name="app_roles"), nullable=False)
     user_captains: list["UserCaptainCluster"] = Relationship(back_populates="user_role", cascade_delete=False)
 
     user_profile: Optional["UserProfile"] = Relationship(
-        back_populates="user_roles", cascade_delete=False,
+        back_populates="user_role", cascade_delete=False,
     )

--- a/src/support_sphere_py/tests/resources/scripts/role_based_access_control.py
+++ b/src/support_sphere_py/tests/resources/scripts/role_based_access_control.py
@@ -1,0 +1,117 @@
+import logging
+from sqlalchemy import text
+from sqlalchemy.orm import sessionmaker
+from support_sphere import engine
+
+logger = logging.getLogger(__name__)
+
+Session = sessionmaker(bind=engine)
+session = Session()
+
+# SQL for custom_access_token_hook function
+custom_access_token_hook_sql = """
+BEGIN;
+  -- Add user_role as part of access token claim
+  CREATE OR REPLACE FUNCTION public.custom_access_token(event jsonb)
+  RETURNS jsonb
+  LANGUAGE plpgsql
+  STABLE
+  AS $$
+    DECLARE
+      claims jsonb;
+      user_role public.app_roles;
+    BEGIN
+      -- Fetch the user role from the user_roles table
+      SELECT role INTO user_role
+      FROM public.user_roles
+      WHERE user_profile_id = (event->>'user_id')::uuid;
+
+      claims := event->'claims';
+
+      -- Set or remove the user_role claim based on the presence of user_role
+      IF user_role IS NOT NULL THEN
+        claims := jsonb_set(claims, '{user_role}', to_jsonb(user_role));
+      ELSE
+        claims := jsonb_set(claims, '{user_role}', 'null');
+      END IF;
+
+      -- Update the 'claims' object in the original event
+      event := jsonb_set(event, '{claims}', claims);
+
+      -- Return the modified event
+      RETURN event;
+    END;
+  $$;
+
+  -- Grant permissions
+  GRANT USAGE ON SCHEMA public TO supabase_auth_admin;
+  GRANT EXECUTE ON FUNCTION public.custom_access_token TO supabase_auth_admin;
+
+  -- Revoke permissions
+  REVOKE EXECUTE ON FUNCTION public.custom_access_token FROM authenticated, anon, public;
+  
+  GRANT ALL ON TABLE public.user_roles TO supabase_auth_admin;
+  
+  REVOKE ALL ON TABLE public.user_roles FROM authenticated, anon, public;
+  
+  CREATE POLICY "Allow auth admin to read user roles" ON public.user_roles AS PERMISSIVE FOR SELECT TO supabase_auth_admin USING (true);
+  
+  ALTER TABLE public.user_roles ENABLE ROW LEVEL SECURITY;
+  
+  COMMIT;
+"""
+
+# SQL for role_based_authorization function
+role_based_authorization_sql = """
+BEGIN;
+  -- Function to check if the user is allowed to perform a certain operation
+  CREATE OR REPLACE FUNCTION public.authorize(
+    requested_permission public.app_permissions
+  )
+  RETURNS boolean AS $$
+  DECLARE
+    bind_permissions int;
+    user_role public.app_roles;
+  BEGIN
+    -- Fetch user role from JWT claims
+    SELECT (auth.jwt() ->> 'user_role')::public.app_roles INTO user_role;
+
+    -- Check if the user's role has the requested permission
+    SELECT count(*)
+    INTO bind_permissions
+    FROM public.role_permissions
+    WHERE role_permissions.permission = requested_permission
+      AND role_permissions.role = user_role;
+
+    -- Return true if the permission is granted, otherwise false
+    RETURN bind_permissions > 0;
+  END;
+  $$ LANGUAGE plpgsql STABLE SECURITY DEFINER SET search_path = '';
+  
+  CREATE POLICY "Allow authorized SELECT access" on public.operational_events FOR SELECT USING ( (SELECT authorize('OPERATIONAL_EVENT_READ')) );
+  CREATE POLICY "Allow authorized INSERT access" on public.operational_events FOR INSERT WITH CHECK (authorize('OPERATIONAL_EVENT_CREATE'));
+  CREATE POLICY "Allow authorized UPDATE access" on public.operational_events FOR UPDATE USING ( (SELECT authorize('OPERATIONAL_EVENT_CREATE')) );
+  
+  ALTER TABLE public.operational_events ENABLE ROW LEVEL SECURITY;
+  
+COMMIT;
+"""
+
+# Execute the SQL commands
+def execute_custom_sql_statement(sql_text):
+    with session:
+        try:
+            session.execute(text(sql_text))
+            session.commit()  # Commit the transaction if successful
+            logger.info("Functions executed successfully.")
+        except Exception as ex:
+            session.rollback()  # Rollback in case of an error
+            logger.info(f"Error occurred while executing {sql_text}:\n{ex}")
+
+
+if __name__ == '__main__':
+    logger.info("Executing custom_access_token_hook_sql...")
+    execute_custom_sql_statement(custom_access_token_hook_sql)
+
+    logger.info("Execution role_based_authorization_sql...")
+    execute_custom_sql_statement(role_based_authorization_sql)

--- a/src/support_sphere_py/tests/resources/scripts/update_db_sample_data.py
+++ b/src/support_sphere_py/tests/resources/scripts/update_db_sample_data.py
@@ -1,4 +1,7 @@
 import csv
+import datetime
+import uuid
+
 import yaml
 from pathlib import Path
 from supabase import create_client, Client
@@ -10,7 +13,7 @@ from support_sphere.repositories.auth import UserRepository
 from support_sphere.repositories.base_repository import BaseRepository
 from support_sphere.repositories.public import UserProfileRepository, PeopleRepository
 
-from support_sphere.models.enums import AppRoles, AppPermissions
+from support_sphere.models.enums import AppRoles, AppPermissions, OperationalStatus
 
 import logging
 
@@ -84,21 +87,23 @@ def authenticate_user_signup_signin_signout_via_supabase(supabase: Client):
 
     # The password is stored in an encrypted format in the auth.users table
     response_sign_up = supabase.auth.sign_up({"email": "zeta@abc.com", "password": "zetazeta"})
-    logger.info(response_sign_up)
     supabase.auth.sign_out()
     response_sign_in = supabase.auth.sign_in_with_password({"email": "zeta@abc.com", "password": "zetazeta"})
-    logger.info(response_sign_in)
     supabase.auth.sign_out()
 
 
 def update_user_permissions_roles_by_cluster():
     role_1 = RolePermission(role=AppRoles.ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_READ)
     role_2 = RolePermission(role=AppRoles.ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_CREATE)
-    role_3 = RolePermission(role=AppRoles.CAPTAIN, permission=AppPermissions.OPERATIONAL_EVENT_READ)
+    role_3 = RolePermission(role=AppRoles.MANAGER, permission=AppPermissions.OPERATIONAL_EVENT_CREATE)
+    role_4 = RolePermission(role=AppRoles.MANAGER, permission=AppPermissions.OPERATIONAL_EVENT_READ)
+    role_5 = RolePermission(role=AppRoles.CAPTAIN, permission=AppPermissions.OPERATIONAL_EVENT_READ)
 
     BaseRepository.add(role_1)
     BaseRepository.add(role_2)
     BaseRepository.add(role_3)
+    BaseRepository.add(role_4)
+    BaseRepository.add(role_5)
 
     user_profile = UserProfileRepository.find_by_username('adamabacus')
     user_role = UserRole(user_profile=user_profile, role=AppRoles.CAPTAIN)
@@ -106,6 +111,49 @@ def update_user_permissions_roles_by_cluster():
 
     cluster_role = UserCaptainCluster(cluster_id=1, user_role=user_role)
     BaseRepository.add(cluster_role)
+
+    user_profile = UserProfileRepository.find_by_username('bethbodmas')
+    user_role = UserRole(user_profile=user_profile, role=AppRoles.MANAGER)
+    BaseRepository.add(user_role)
+
+
+def test_app_mode_status_update(supabase: Client):
+
+    response_sign_in = supabase.auth.sign_in_with_password(
+        {"email": "beth.bodmas@example.com", "password": "bethbodmas"})
+
+    user_profile = UserProfileRepository.find_by_username('bethbodmas')
+    supabase.table("operational_events").insert({"id": str(uuid.uuid4()),
+                                                 "created_by": str(user_profile.id),
+                                                 "created_at": datetime.datetime.now().isoformat(),
+                                                 "status": OperationalStatus.EMERGENCY.name}).execute()
+
+    supabase.table("operational_events").insert({"id": str(uuid.uuid4()),
+                                                 "created_by": str(user_profile.id),
+                                                 "created_at": datetime.datetime.now().isoformat(),
+                                                 "status": OperationalStatus.TEST.name}).execute()
+
+    supabase.table("operational_events").insert({"id": str(uuid.uuid4()),
+                                                 "created_by": str(user_profile.id),
+                                                 "created_at": datetime.datetime.now().isoformat(),
+                                                 "status": OperationalStatus.NORMAL.name}).execute()
+    supabase.auth.sign_out()
+
+
+def test_unauthorized_app_mode_update(supabase: Client):
+    try:
+        response_sign_in = supabase.auth.sign_in_with_password(
+            {"email": "adam.abacus@example.com", "password": "adamabacus"})
+        user_profile = UserProfileRepository.find_by_username('adamabacus')
+        supabase.table("operational_events").insert({"id": str(uuid.uuid4()),
+                                                     "created_by": str(user_profile.id),
+                                                     "created_at": datetime.datetime.now().isoformat(),
+                                                     "status": OperationalStatus.EMERGENCY.name}).execute()
+    except Exception as ex:
+        logger.info(ex)
+        logger.info("[CORRECT BEHAVIOUR]: User Denied Access for missing AUTHz.")
+    finally:
+        supabase.auth.sign_out()
 
 
 if __name__ == '__main__':
@@ -116,5 +164,5 @@ if __name__ == '__main__':
     populate_cluster_and_household_details()
     populate_user_details(supabase)
     update_user_permissions_roles_by_cluster()
-    
-
+    test_app_mode_status_update(supabase)
+    test_unauthorized_app_mode_update(supabase)


### PR DESCRIPTION
Fixes #30 

- [x] add custom access token hook for user_role on session JWT access token as postgres function
- [x] add `operational_events` table
- [x] add `notes` field to `cluster` table
- [x] add `authorize() `SQL function for role-based access control based on table `role_permissions`
- [x] add policies and enable row-level security for table 'operational_events' and 'user_roles'
- [x] add sample data entry and authz test for app emergency status update