### PR TITLE
feat: Only create the scheduled action to shut down the server everyday in non-prod stages

### DIFF
--- a/deployment/cloud/main.tf
+++ b/deployment/cloud/main.tf
@@ -41,6 +41,7 @@ module "server" {
   
   resource_prefix = local.resource_prefix
   instance_type = var.instance_type
+  stage = var.stage
 }
 
 resource "aws_resourcegroups_group" "this" {

--- a/deployment/cloud/modules/server/main.tf
+++ b/deployment/cloud/modules/server/main.tf
@@ -169,9 +169,10 @@ resource "aws_autoscaling_group" "this" {
 }
 
 // Autoscaling action to shutdown the server every weekday at 1AM UTC (6PM PDT/5PM PST)
-// Replaces an overcomplicated lambda function/eventbridge rule setup
-
 resource "aws_autoscaling_schedule" "scale_down" {
+  # only create this resource in non-prod environments
+  count = var.stage != "prod" ? 1 : 0
+
   scheduled_action_name = "${var.resource_prefix}-asg-shutdown-after-working-hours"
   min_size = 0
   desired_capacity = 0

--- a/deployment/cloud/modules/server/variables.tf
+++ b/deployment/cloud/modules/server/variables.tf
@@ -7,3 +7,13 @@ variable "instance_type" {
     description = "The instance type to use for the server"
     type        = string
 }
+
+variable "stage" {
+    description = "Which stage this infrastructure's being deployed to - dev, beta, prod, etc."
+    type        = string
+
+    validation {
+        condition = can(regex("^(dev|beta|prod)$", var.stage))
+        error_message = "Stage must be one of dev, beta, or prod"
+    }
+}

--- a/deployment/cloud/variables.tf
+++ b/deployment/cloud/variables.tf
@@ -8,6 +8,16 @@ variable "neighborhood" {
     type        = string
 }
 
+variable "stage" {
+    description = "Which stage this infrastructure's being deployed to - dev, beta, prod, etc."
+    type        = string
+
+    validation {
+        condition = can(regex("^(dev|beta|prod)$", var.stage))
+        error_message = "Stage must be one of dev, beta, or prod"
+    }
+}
+
 variable "additional_tags" {
     description = "Additional tags to apply to resources"
     type        = map(string)

--- a/pixi.toml
+++ b/pixi.toml
@@ -142,6 +142,7 @@ depends-on = ["install-flutter"]
 [feature.cloud.activation.env]
 "TF_VAR_project_name" = "Support Sphere"
 "TF_VAR_neighborhood" = "Laurelhurst"
+"TF_VAR_stage" = "dev"
 
 [feature.cloud.tasks]
 # empty for now


### PR DESCRIPTION
Came back to this today and remembered that we should only shutdown the server everyday in non-prod environments. Figured I'd add a new input variable, `stage`, with the currently-accepted values of `dev`, `beta`, and `prod` to help determine all of this. We'd be developing exclusively under the `dev` stage.

Feel free to tell me that this is unnecessary at this stage! Totally happy to drop this and move on :)

## Validation

Providing `dev` as the `stage` envvar:

```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy

OpenTofu will perform the following actions:

  # module.server.aws_autoscaling_schedule.scale_down has moved to module.server.aws_autoscaling_schedule.scale_down[0]
    resource "aws_autoscaling_schedule" "scale_down" {
        id                     = "supportsphere-laurelhurst-asg-shutdown-after-working-hours"
        # (8 unchanged attributes hidden)
    }
```

Providing `prod` as the `stage` envvar:

```
OpenTofu used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  ~ update in-place
  - destroy

OpenTofu will perform the following actions:

  # module.server.aws_autoscaling_schedule.scale_down[0] will be destroyed
  # (because index [0] is out of range for count)
  # (moved from module.server.aws_autoscaling_schedule.scale_down)
  - resource "aws_autoscaling_schedule" "scale_down" {
      - arn                    = "arn:aws:autoscaling:us-west-2:871683513797:scheduledUpdateGroupAction:f949b83a-1b9d-4d30-85f4-1e15f18a5caf:autoScalingGroupName/supportsphere-laurelhurst-asg:scheduledActionName/supportsphere-laurelhurst-asg-shutdown-after-working-hours" -> null
      - autoscaling_group_name = "supportsphere-laurelhurst-asg" -> null
      - desired_capacity       = 0 -> null
      - id                     = "supportsphere-laurelhurst-asg-shutdown-after-working-hours" -> null
      - max_size               = 1 -> null
      - min_size               = 0 -> null
      - recurrence             = "0 1 * * MON-FRI" -> null
      - scheduled_action_name  = "supportsphere-laurelhurst-asg-shutdown-after-working-hours" -> null
      - start_time             = "2024-09-10T01:00:00Z" -> null
    }
```

## Open Discussion
Should we include the `stage` name in the resource prefix?
* eg, `supportsphere-laurelhurst-instance-role` would now be called `supportsphere-laurelhurst-dev-instance-role`