### PR TITLE
feat: Add script to access running cloud server via ssm

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ The server will stop daily at 01:00 UTC (6PM PDT/5PM PST), but if you wanna be a
 pixi run cloud-server-stop
 ```
 
+### Access the development server when it's running
+
+This command uses [AWS's Session Manager](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager.html) to access the development server without needing to distribute ssh keys. Assuming you have access to the IAM roles needed for everything else related to the cloud here, this command should just work!
+
+```
+pixi run cloud-server-access
+```
+
 
 ## Contributing
 

--- a/deployment/cloud/modules/server/main.tf
+++ b/deployment/cloud/modules/server/main.tf
@@ -220,3 +220,45 @@ resource "aws_iam_role" "scaling" {
         })
     }
 }
+
+resource "aws_iam_role" "access" {
+    name = "${var.resource_prefix}-server-access-role"
+    assume_role_policy = jsonencode({
+        Version = "2012-10-17",
+        Statement = [
+            {
+                Effect = "Allow",
+                Principal = {
+                    AWS = "arn:aws:iam::${data.aws_caller_identity.this.account_id}:root"
+                },
+                Action = "sts:AssumeRole"
+            }
+        ]
+    })
+
+    inline_policy {
+        name = "${var.resource_prefix}_server_access_policy"
+        policy = jsonencode({
+            Version = "2012-10-17",
+            Statement = [
+                {
+                    Effect = "Allow",
+                    Action = [
+                        "ssm:StartSession"
+                    ],
+                    Resource = [
+                      "arn:aws:ssm:${data.aws_region.this.name}::document/AWS-StartInteractiveCommand",
+                      "arn:aws:ec2:${data.aws_region.this.name}:${data.aws_caller_identity.this.account_id}:instance/*"
+                    ]
+                },
+                {
+                    Effect = "Allow",
+                    Action = [
+                        "ec2:DescribeInstances"
+                    ],
+                    Resource = "*"
+                }
+            ]
+        })
+    }
+}

--- a/pixi.lock
+++ b/pixi.lock
@@ -271,18 +271,33 @@ environments:
       linux-64:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-2_gnu.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.8-h538f98c_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-h0bcb0bb_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-hd268abd_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-he0cd244_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.10-h35285c7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.4-h0448019_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h7f92143_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/aws-session-manager-plugin-1.2.650.0-ha8f183a_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.15.24-py311h38be061_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.19.19-py311ha8d3014_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-h4bc722e_7.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ca-certificates-2024.8.30-hbcca054_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py312h06ac9bb_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/cryptography-40.0.2-py311h9b4c7bb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py311h38be061_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.40-hf3520f5_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.2-h59595ed_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.4.2-h7f98852_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-14.1.0-h77fa898_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libgcc-ng-14.1.0-h69a702a_1.conda
@@ -297,86 +312,132 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.5-he02047a_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.3.2-hb9d3cd8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/opentofu-1.8.1-ha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.12.5-h2ad013b_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.2-h8228510_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.21-py311h2582759_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.7-py311h459d7ec_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.0-h06160fa_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h4845f30_101.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xz-5.2.6-h166bdaf_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.6-ha6fb4c9_0.conda
       osx-64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.8-hcd8a21d_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-had988b7_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.10-h10d778d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hb45f1eb_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-hbc2660c_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.14-h1fa4523_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.36-h3728bb0_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.10-h2150435_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.4-h960c460_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-hb45f1eb_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hb45f1eb_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/aws-session-manager-plugin-1.2.650.0-h990441c_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.15.24-py311h6eed73b_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/awscrt-0.19.19-py311h4bdfc93_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py312h5861a67_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-hfdf4475_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ca-certificates-2024.8.30-h8857fd0_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.0-py312hf857d28_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/cryptography-40.0.2-py311h61927ef_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.19-py311h6eed73b_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libcxx-18.1.8-hd876a4e_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.2-h73e2aa4_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.4.2-h0d85af4_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.46.1-h4b8f8c9_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.1-h87427d6_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.5-hf036a51_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.3.2-hd23fc13_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/opentofu-1.8.1-h694c41f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.12.5-h37a9e06_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-h8f8b54e_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.2-h9e318b2_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.17.21-py311h5547dcb_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.7-py311h2725bcf_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-h1abcd95_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/xz-5.2.6-h775f41a_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h7122b0e_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.6-h915ae27_0.conda
       osx-arm64:
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.8-h76f1ccf_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-hb1772db_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.10-h93a5062_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-hb1772db_7.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hb5e90b3_8.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.14-hd747585_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.36-h1112932_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.10-h99ceed4_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.4-hc25d294_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.13-hb1772db_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-hb1772db_6.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/aws-session-manager-plugin-1.2.650.0-h75b854d_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.15.24-py311h267d04e_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/awscrt-0.19.19-py311h39eef5c_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/boto3-1.35.11-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/botocore-1.35.11-pyge310_1234567_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hde4cb15_2.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h99b78c6_7.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ca-certificates-2024.8.30-hf0a4a13_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.0-py312h0fad829_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-40.0.2-py311h507f6e9_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.19-py311h267d04e_1.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/noarch/jmespath-1.0.1-pyhd8ed1ab_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-18.1.8-h3ed4263_7.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.2-hebf3989_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.4.2-h3422bc3_5.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.46.1-hc14010f_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.1-hfb2fe0b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.5-h7bae524_1.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.3.2-h8359307_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/opentofu-1.8.1-hce30654_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.1.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pysocks-1.7.1-pyha2e5f31_6.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.12.5-h30c5eda_0_cpython.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-h739c21a_0_cpython.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python-dateutil-2.9.0-pyhd8ed1ab_0.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.2-h92ec313_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.17.21-py311he2be06e_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.7-py311heffc1b2_2.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/s3transfer-0.10.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/six-1.16.0-pyh6c4a22f_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h5083fa2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2024a-h8827d51_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/wcwidth-0.2.13-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/xz-5.2.6-h57fd34a_0.tar.bz2
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312h15fbf35_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.6-hb46c0d2_0.conda
   frontend:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -689,6 +750,761 @@ packages:
   size: 28922
   timestamp: 1698341257884
 - kind: conda
+  name: aws-c-auth
+  version: 0.7.8
+  build: h538f98c_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-auth-0.7.8-h538f98c_2.conda
+  sha256: b06ef95458fc70af4230c9c6690011235cd25288752ff7aa25492fc6d1c0e028
+  md5: d42aebb91e28e2fee2a0218cfbff2c90
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 102992
+  timestamp: 1702039736949
+- kind: conda
+  name: aws-c-auth
+  version: 0.7.8
+  build: h76f1ccf_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-auth-0.7.8-h76f1ccf_2.conda
+  sha256: 36f3bb471e30b10bc8f640c2857eabeb12ce03157271d07e7ea42ce55ef30993
+  md5: b9b6f495ef60a7841727b2b10d80a51e
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88444
+  timestamp: 1702040220734
+- kind: conda
+  name: aws-c-auth
+  version: 0.7.8
+  build: hcd8a21d_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-auth-0.7.8-hcd8a21d_2.conda
+  sha256: 51113c35a53be507585db10fc11097627241b27d5a024f632e78414c38309cd9
+  md5: bd1c1f57c9aca263fcdd3d8fb7b0c264
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-c-sdkutils >=0.1.13,<0.1.14.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 90167
+  timestamp: 1702040195477
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.9
+  build: h5d48c4d_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-cal-0.6.9-h5d48c4d_2.conda
+  sha256: ec56734a24eee51e2f89bec3d686dd2c4dbb09d0305248b1d14e4c748065dc23
+  md5: 9e51dfd5da37c1817d2a850188861987
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  - openssl >=3.2.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 55554
+  timestamp: 1701212359409
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.9
+  build: had988b7_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-cal-0.6.9-had988b7_2.conda
+  sha256: 22f1272836f73b133912b0b77a0c832366d3bcdfef3a4df1dd4efd2409128e60
+  md5: 2a5755b9c5f9765a9967b277fb8a832b
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 45613
+  timestamp: 1701212818559
+- kind: conda
+  name: aws-c-cal
+  version: 0.6.9
+  build: hb1772db_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-cal-0.6.9-hb1772db_2.conda
+  sha256: 7059960c1e765461227da57112fa3aabcef2292c83499d0440da46ec938ba017
+  md5: 412ec63d1ac917e45f3206dd29dcc7e8
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 39662
+  timestamp: 1701212885323
+- kind: conda
+  name: aws-c-common
+  version: 0.9.10
+  build: h10d778d_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-common-0.9.10-h10d778d_0.conda
+  sha256: 34d04f691bc4ff924627314ecbb7f4c7b9dd779f3ed5576f12d61e073536a8bb
+  md5: d639668144f530bf8b6f56d4b5a64f3c
+  license: Apache-2.0
+  license_family: Apache
+  size: 207354
+  timestamp: 1701170066323
+- kind: conda
+  name: aws-c-common
+  version: 0.9.10
+  build: h93a5062_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-common-0.9.10-h93a5062_0.conda
+  sha256: 3269c3773d02262132cff14819bb606360c2ca44cdf9373e1a67f118c7a5232b
+  md5: 7b7bd1f14689ddec8131a0c4111790ca
+  license: Apache-2.0
+  license_family: Apache
+  size: 204196
+  timestamp: 1701169900533
+- kind: conda
+  name: aws-c-common
+  version: 0.9.10
+  build: hd590300_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-common-0.9.10-hd590300_0.conda
+  sha256: dba8a20acedc6bc3574e4068c196969881462ad831aae267d25fbc9409785a6b
+  md5: 93729f7a54b25cb135ac2b67ea3a7603
+  depends:
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 225475
+  timestamp: 1701169650086
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: h7f92143_7
+  build_number: 7
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-compression-0.2.17-h7f92143_7.conda
+  sha256: ce508018c1109d4e5c6b65695639deaa2beea31edc39145bb810efb13ffed2c3
+  md5: c55a1a0c1419fcdfce6d21c41b0f92ab
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 19185
+  timestamp: 1701212362896
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: hb1772db_7
+  build_number: 7
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-compression-0.2.17-hb1772db_7.conda
+  sha256: e74330ffc64ac9bd9eb89c1e9d1004fe9b2aa689ecf8d5a94fdb17438237659b
+  md5: 5363bbd9ffcea69e9ef383766dcc49e0
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18255
+  timestamp: 1701212799172
+- kind: conda
+  name: aws-c-compression
+  version: 0.2.17
+  build: hb45f1eb_7
+  build_number: 7
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-compression-0.2.17-hb45f1eb_7.conda
+  sha256: 0d8e18977a54eea25826836cd20cc05f620f4165d3d94b7d4300583fb698a3a8
+  md5: 745ce5b224f24179d94287c190464ecb
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 18129
+  timestamp: 1701212675008
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: h0bcb0bb_8
+  build_number: 8
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-event-stream-0.3.2-h0bcb0bb_8.conda
+  sha256: d2855cd791a95648ac773aa6561c61f9e77450f123c8aa82eea1d66e90d5bfb1
+  md5: 21dafb60b5854f82b196f32e5857dec6
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - libstdcxx-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 54136
+  timestamp: 1701263274039
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: hb5e90b3_8
+  build_number: 8
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-event-stream-0.3.2-hb5e90b3_8.conda
+  sha256: c9495e5133feacacef792a8f3101f1e44464144c603fccd7f1b6262975983094
+  md5: 43263bfb2e9a2cc4162bcf90ce9c73b9
+  depends:
+  - __osx >=10.9
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=16.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47429
+  timestamp: 1701263443184
+- kind: conda
+  name: aws-c-event-stream
+  version: 0.3.2
+  build: hbc2660c_8
+  build_number: 8
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-event-stream-0.3.2-hbc2660c_8.conda
+  sha256: d57c92483040d58b6653b0273a1a2570cc79ff5eb8ac2c2b18a85099e7576983
+  md5: ffada75190a10b0d60271b147fd877a4
+  depends:
+  - __osx >=10.9
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libcxx >=16.0.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 47252
+  timestamp: 1701263477904
+- kind: conda
+  name: aws-c-http
+  version: 0.7.14
+  build: h1fa4523_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-http-0.7.14-h1fa4523_3.conda
+  sha256: 0e6558e17d15db3bf914c70f7c61d45761e7a284ac69d8d5444b5e00f3deee05
+  md5: 4c49ac0d21f8645d35a8b031013ef36e
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 162065
+  timestamp: 1701248838294
+- kind: conda
+  name: aws-c-http
+  version: 0.7.14
+  build: hd268abd_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-http-0.7.14-hd268abd_3.conda
+  sha256: ff7e6252a299a59b7e6494723ef3043ba31643ec2a750b8593037bc757a2c4fa
+  md5: 0b0f7174a0f94d2c9a02fb24f6fc0d00
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 194249
+  timestamp: 1701248521692
+- kind: conda
+  name: aws-c-http
+  version: 0.7.14
+  build: hd747585_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-http-0.7.14-hd747585_3.conda
+  sha256: 71dc46c49e033aa3eedb43433981334b85623f7b7ea6b65ea99d9bb0cd0a2f46
+  md5: 7c2b05d673ad261a1fb5711350e645a5
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-compression >=0.2.17,<0.2.18.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 150984
+  timestamp: 1701248891898
+- kind: conda
+  name: aws-c-io
+  version: 0.13.36
+  build: h1112932_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-io-0.13.36-h1112932_3.conda
+  sha256: 8770803baa7323891abcf892e36abce13d6f67d675ebe91ab538621f90e8319f
+  md5: 732c739df5de131665801871650c2399
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 136832
+  timestamp: 1703277731454
+- kind: conda
+  name: aws-c-io
+  version: 0.13.36
+  build: h3728bb0_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-io-0.13.36-h3728bb0_3.conda
+  sha256: 6e6698f3f7ccc3b7adc4eff3c1fc0f01f28960a67b7cfbd8ada2f9e1e5aae957
+  md5: 5fb516f968b8465843147e70502b3b30
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 137884
+  timestamp: 1703277470793
+- kind: conda
+  name: aws-c-io
+  version: 0.13.36
+  build: he0cd244_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-io-0.13.36-he0cd244_2.conda
+  sha256: 7426f7444cd43cd7a649670c7330c163b40f40aa832e82be873d9de91e49b05e
+  md5: c930336aa72995f1b5459b51df3ba841
+  depends:
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  - s2n >=1.4.0,<1.4.1.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 156952
+  timestamp: 1702039096578
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.9.10
+  build: h2150435_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-mqtt-0.9.10-h2150435_2.conda
+  sha256: 2e34bd46afb0b0c9d08e3fb088d81752a07d8a1fe05fa7f3ffa9d394cab82919
+  md5: 3b86790d13b949fd23edb385fc15f2db
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 139060
+  timestamp: 1701264317693
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.9.10
+  build: h35285c7_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-mqtt-0.9.10-h35285c7_2.conda
+  sha256: 246276b22393302b4e9acb934ec40bb78d3be74e7bd2c110272b46c5370a60ee
+  md5: 0cca0a3d7dc82f219ac46635478952f6
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 164618
+  timestamp: 1701264087679
+- kind: conda
+  name: aws-c-mqtt
+  version: 0.9.10
+  build: h99ceed4_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-mqtt-0.9.10-h99ceed4_2.conda
+  sha256: 537ea079e4d44606134f64220d4676afe16487470725d8075778017ae3d8e9eb
+  md5: e65083cbeba6dd468c960107b08d89d3
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 118280
+  timestamp: 1701264068201
+- kind: conda
+  name: aws-c-s3
+  version: 0.4.4
+  build: h0448019_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-s3-0.4.4-h0448019_0.conda
+  sha256: 04142edf1a574e137a9e30a4f4e9b9448e219b6f4216a782ceaed933f27852a6
+  md5: f27f792aa83c7be3ee96d09a637a6474
+  depends:
+  - aws-c-auth >=0.7.8,<0.7.9.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - openssl >=3.2.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 103004
+  timestamp: 1702065571082
+- kind: conda
+  name: aws-c-s3
+  version: 0.4.4
+  build: h960c460_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-s3-0.4.4-h960c460_0.conda
+  sha256: 12c8f228ffe971536f5297dce62759fb2fe8d1343078c6cd6f64c54f633e9288
+  md5: 4fe9cea0ae2928652dca7414046adc04
+  depends:
+  - aws-c-auth >=0.7.8,<0.7.9.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 89540
+  timestamp: 1702065721323
+- kind: conda
+  name: aws-c-s3
+  version: 0.4.4
+  build: hc25d294_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-s3-0.4.4-hc25d294_0.conda
+  sha256: 41d07738151cddec125e614c734c4c1c2c826044bf4d051ee6dcf19a2b682ef3
+  md5: 9043dd3856a16bd99ba30ab54c3a6f0d
+  depends:
+  - aws-c-auth >=0.7.8,<0.7.9.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 88540
+  timestamp: 1702065765958
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.13
+  build: h7f92143_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-c-sdkutils-0.1.13-h7f92143_0.conda
+  sha256: 8696e7023fde7c4588db8aedd08ffc0b4041c8449bd9edd50f237534cbcfac93
+  md5: a4a83424ad4eab023c6e5b4adf264006
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 53339
+  timestamp: 1701999463183
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.13
+  build: hb1772db_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-c-sdkutils-0.1.13-hb1772db_0.conda
+  sha256: d9a89a98fea5d371cf0370c3f43479450932de070e960961d834624d00ead950
+  md5: 90291cf2e5e350b154f3fe1de4390af8
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47384
+  timestamp: 1701999707452
+- kind: conda
+  name: aws-c-sdkutils
+  version: 0.1.13
+  build: hb45f1eb_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-c-sdkutils-0.1.13-hb45f1eb_0.conda
+  sha256: 8224bc5d6a9659e165e7c1cd4b22f3b9ca5cda5ae5d7ce0ac54961035bf0c535
+  md5: 7bd97891383c905c06f1508405290cc0
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 47467
+  timestamp: 1701999663058
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: h7f92143_6
+  build_number: 6
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-checksums-0.1.17-h7f92143_6.conda
+  sha256: ac2082211e7d5fd3036f9abd7e398ef67d5327efb3808f17a30fcab59acacbfb
+  md5: 46bd4e9c2fd10de83bae22f0bb71139b
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - libgcc-ng >=12
+  license: Apache-2.0
+  license_family: Apache
+  size: 50162
+  timestamp: 1701246709430
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: hb1772db_6
+  build_number: 6
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-checksums-0.1.17-hb1772db_6.conda
+  sha256: 9c72adde6dd106aa0ce0bc21252a9a5c9645c9efb93b5f9c08a914e45a3ad78c
+  md5: da58c3c6dcf40cfa69a0a74a7acf355c
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 49237
+  timestamp: 1701247014330
+- kind: conda
+  name: aws-checksums
+  version: 0.1.17
+  build: hb45f1eb_6
+  build_number: 6
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-checksums-0.1.17-hb45f1eb_6.conda
+  sha256: a09f546c5d9a658bd4ce51f4432a7f82e59c9416faf3b7902b06d1aaffcbeb56
+  md5: 3c93bf40376489c5c880be77ba47f5c0
+  depends:
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 48848
+  timestamp: 1701246965518
+- kind: conda
+  name: aws-session-manager-plugin
+  version: 1.2.650.0
+  build: h75b854d_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/aws-session-manager-plugin-1.2.650.0-h75b854d_0.conda
+  sha256: 5ff3d70dd92ae14548685aa2a60e409cba35c86fe4571dbfd7c7b4bb4e8461cd
+  md5: eea6be7689059f36c825c57aa01df31d
+  depends:
+  - awscli
+  license: Apache-2.0
+  license_family: Apache
+  size: 7129599
+  timestamp: 1720005524127
+- kind: conda
+  name: aws-session-manager-plugin
+  version: 1.2.650.0
+  build: h990441c_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/aws-session-manager-plugin-1.2.650.0-h990441c_0.conda
+  sha256: 0d5906fe9b0456befc7eba497d02a9b5d0aaa537932f617dd8e69fba207a2192
+  md5: 93cabb62eb49c859df6a064469d8f4bf
+  depends:
+  - awscli
+  constrains:
+  - __osx>=10.12
+  license: Apache-2.0
+  license_family: Apache
+  size: 7575875
+  timestamp: 1720005473916
+- kind: conda
+  name: aws-session-manager-plugin
+  version: 1.2.650.0
+  build: ha8f183a_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/aws-session-manager-plugin-1.2.650.0-ha8f183a_0.conda
+  sha256: 77df6dfa687e04701c5559f786cd474ee433a1cbf8479f80306710f48c48706d
+  md5: f6c507c414a57039739aa815a177b5a7
+  depends:
+  - awscli
+  license: Apache-2.0
+  license_family: Apache
+  size: 7374210
+  timestamp: 1720005508164
+- kind: conda
+  name: awscli
+  version: 2.15.24
+  build: py311h267d04e_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/awscli-2.15.24-py311h267d04e_0.conda
+  sha256: 85b3c5650bd31dc0e8930d97f3668400c0a7342f908cdc177226f7be57c77a18
+  md5: 210be79462abd0e416b6727537a86c4f
+  depends:
+  - awscrt >=0.19.18,<=0.19.19
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=3.3.2,<=40.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - pyopenssl <23.2
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python-dateutil >=2.1,<3.0.0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.7
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12072481
+  timestamp: 1709163450841
+- kind: conda
+  name: awscli
+  version: 2.15.24
+  build: py311h38be061_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscli-2.15.24-py311h38be061_0.conda
+  sha256: 1aa35cc42762ae7e1202684dd27c7dd41abfa6299def6ff01adba864a86b43d4
+  md5: 9d5d457877ec32bb9717bbd34f09bc01
+  depends:
+  - awscrt >=0.19.18,<=0.19.19
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=3.3.2,<=40.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - pyopenssl <23.2
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.1,<3.0.0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.7
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12059637
+  timestamp: 1709162928727
+- kind: conda
+  name: awscli
+  version: 2.15.24
+  build: py311h6eed73b_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/awscli-2.15.24-py311h6eed73b_0.conda
+  sha256: 701c722ae3450dc29866cb0f4e5cea4a60b794da86ec0266f2e9552af122f4c3
+  md5: b7b9829e7bf8251d6dd00bf162590402
+  depends:
+  - awscrt >=0.19.18,<=0.19.19
+  - colorama >=0.2.5,<0.4.7
+  - cryptography >=3.3.2,<=40.0.2
+  - distro >=1.5.0,<1.9.0
+  - docutils >=0.10,<0.20
+  - jmespath >=0.7.1,<1.1.0
+  - prompt_toolkit >=3.0.24,<3.0.39
+  - pyopenssl <23.2
+  - python >=3.11,<3.12.0a0
+  - python-dateutil >=2.1,<3.0.0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml >=0.15.0,<=0.17.21
+  - ruamel.yaml.clib >=0.2.0,<=0.2.7
+  - urllib3 >=1.25.4,<1.27
+  license: Apache-2.0
+  license_family: APACHE
+  size: 12098053
+  timestamp: 1709163341590
+- kind: conda
+  name: awscrt
+  version: 0.19.19
+  build: py311h39eef5c_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/awscrt-0.19.19-py311h39eef5c_2.conda
+  sha256: e23d13d54ded2740d398fadd9beb9ab78ef84fdc5a56480320bec3ba2ae9cd78
+  md5: 21a76448e38a79b5163106aeab0110bc
+  depends:
+  - aws-c-auth >=0.7.8,<0.7.9.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-c-mqtt >=0.9.10,<0.9.11.0a0
+  - aws-c-s3 >=0.4.4,<0.4.5.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 183210
+  timestamp: 1702083269344
+- kind: conda
+  name: awscrt
+  version: 0.19.19
+  build: py311h4bdfc93_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/awscrt-0.19.19-py311h4bdfc93_2.conda
+  sha256: ea8614831b4fbd3ba249bdea009fbd677d61412791ebdd8285c615fc9ff2c63d
+  md5: 5b58697fe5874ef22fbc222f9b589e91
+  depends:
+  - aws-c-auth >=0.7.8,<0.7.9.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-c-mqtt >=0.9.10,<0.9.11.0a0
+  - aws-c-s3 >=0.4.4,<0.4.5.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0
+  license_family: APACHE
+  size: 182595
+  timestamp: 1702083211941
+- kind: conda
+  name: awscrt
+  version: 0.19.19
+  build: py311ha8d3014_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/awscrt-0.19.19-py311ha8d3014_2.conda
+  sha256: d44f230870c552131975bbef7c3e047ca33e9c1e4dd74a4040a20f2ecf246558
+  md5: 0f45101c4f9c6e195619a2308975937a
+  depends:
+  - aws-c-auth >=0.7.8,<0.7.9.0a0
+  - aws-c-cal >=0.6.9,<0.6.10.0a0
+  - aws-c-common >=0.9.10,<0.9.11.0a0
+  - aws-c-event-stream >=0.3.2,<0.3.3.0a0
+  - aws-c-http >=0.7.14,<0.7.15.0a0
+  - aws-c-io >=0.13.36,<0.13.37.0a0
+  - aws-c-mqtt >=0.9.10,<0.9.11.0a0
+  - aws-c-s3 >=0.4.4,<0.4.5.0a0
+  - aws-checksums >=0.1.17,<0.1.18.0a0
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - s2n >=1.4.0,<1.4.1.0a0
+  license: Apache-2.0
+  license_family: APACHE
+  size: 192515
+  timestamp: 1702082946440
+- kind: conda
   name: boto3
   version: 1.35.11
   build: pyhd8ed1ab_0
@@ -727,65 +1543,65 @@ packages:
 - kind: conda
   name: brotli-python
   version: 1.1.0
-  build: py312h2ec8cdc_2
-  build_number: 2
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py312h2ec8cdc_2.conda
-  sha256: f2a59ccd20b4816dea9a2a5cb917eb69728271dbf1aeab4e1b7e609330a50b6f
-  md5: b0b867af6fc74b2a0aa206da29c0f3cf
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libstdcxx >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - libbrotlicommon 1.1.0 hb9d3cd8_2
-  license: MIT
-  license_family: MIT
-  size: 349867
-  timestamp: 1725267732089
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py312h5861a67_2
-  build_number: 2
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py312h5861a67_2.conda
-  sha256: 265764ff4ad9e5cfefe7ea85c53d95157bf16ac2c0e5f190c528e4c9c0c1e2d0
-  md5: b95025822e43128835826ec0cc45a551
-  depends:
-  - __osx >=10.13
-  - libcxx >=17
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  constrains:
-  - libbrotlicommon 1.1.0 h00291cd_2
-  license: MIT
-  license_family: MIT
-  size: 363178
-  timestamp: 1725267893889
-- kind: conda
-  name: brotli-python
-  version: 1.1.0
-  build: py312hde4cb15_2
+  build: py311h3f08180_2
   build_number: 2
   subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py312hde4cb15_2.conda
-  sha256: 254b411fa78ccc226f42daf606772972466f93e9bc6895eabb4cfda22f5178af
-  md5: a83c2ef76ccb11bc2349f4f17696b15d
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/brotli-python-1.1.0-py311h3f08180_2.conda
+  sha256: f507d65e740777a629ceacb062c768829ab76fde01446b191699a734521ecaad
+  md5: c8793a23206344faa25f4e0b5d0e7908
   depends:
   - __osx >=11.0
   - libcxx >=17
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
   constrains:
   - libbrotlicommon 1.1.0 hd74edd7_2
   license: MIT
   license_family: MIT
-  size: 339360
-  timestamp: 1725268143995
+  size: 339584
+  timestamp: 1725268241628
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py311hd89902b_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/brotli-python-1.1.0-py311hd89902b_2.conda
+  sha256: 004cefbd18f581636a8dcb1964fb73478f15d496769226ec896c1d4a0161b7d8
+  md5: d75f06ee06001794aa83a05e885f1520
+  depends:
+  - __osx >=10.13
+  - libcxx >=17
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 h00291cd_2
+  license: MIT
+  license_family: MIT
+  size: 363793
+  timestamp: 1725267947069
+- kind: conda
+  name: brotli-python
+  version: 1.1.0
+  build: py311hfdbb021_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/brotli-python-1.1.0-py311hfdbb021_2.conda
+  sha256: 949913bbd1f74d1af202d3e4bff2e0a4e792ec00271dc4dd08641d4221aa2e12
+  md5: d21daab070d76490cb39a8f1d1729d79
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  - libstdcxx >=13
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  constrains:
+  - libbrotlicommon 1.1.0 hb9d3cd8_2
+  license: MIT
+  license_family: MIT
+  size: 350367
+  timestamp: 1725267768486
 - kind: conda
   name: bzip2
   version: 1.0.8
@@ -958,63 +1774,60 @@ packages:
   requires_python: '>=3.6'
 - kind: conda
   name: cffi
-  version: 1.17.0
-  build: py312h06ac9bb_1
-  build_number: 1
+  version: 1.17.1
+  build: py311h137bacd_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.1-py311h137bacd_0.conda
+  sha256: 012ee7b1ed4f9b0490d6e90c72decf148d7575173c7eaf851cd87fd434d2cacc
+  md5: a4b0f531064fa3dd5e3afbb782ea2cd5
+  depends:
+  - __osx >=10.13
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288762
+  timestamp: 1725560945833
+- kind: conda
+  name: cffi
+  version: 1.17.1
+  build: py311h3a79f62_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.1-py311h3a79f62_0.conda
+  sha256: 253605b305cc4548b8f97eb7c2e146697e0c7672b099c4862ec5ca7e8e995307
+  md5: a42272c5dbb6ffbc1a5af70f24c7b448
+  depends:
+  - __osx >=11.0
+  - libffi >=3.4,<4.0a0
+  - pycparser
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 288211
+  timestamp: 1725560745212
+- kind: conda
+  name: cffi
+  version: 1.17.1
+  build: py311hf29c0ef_0
   subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.0-py312h06ac9bb_1.conda
-  sha256: 397f588c30dd1a30236d289d8dc7f3c34cd71a498dc66d20450393014594cf4d
-  md5: db9bdbaee0f524ead0471689f002781e
+  url: https://conda.anaconda.org/conda-forge/linux-64/cffi-1.17.1-py311hf29c0ef_0.conda
+  sha256: bc47aa39c8254e9e487b8bcd74cfa3b4a3de3648869eb1a0b89905986b668e35
+  md5: 55553ecd5328336368db611f350b7039
   depends:
   - __glibc >=2.17,<3.0.a0
   - libffi >=3.4,<4.0a0
   - libgcc >=13
   - pycparser
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
   license: MIT
   license_family: MIT
-  size: 294242
-  timestamp: 1724956485789
-- kind: conda
-  name: cffi
-  version: 1.17.0
-  build: py312h0fad829_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/cffi-1.17.0-py312h0fad829_1.conda
-  sha256: 3e3c78e04269a03e8cac83148b69d6c330cf77b90b8d59e8e321acfb2c16db83
-  md5: cf8e510dbb47809b67fa449104bb4d26
-  depends:
-  - __osx >=11.0
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 280650
-  timestamp: 1724956628231
-- kind: conda
-  name: cffi
-  version: 1.17.0
-  build: py312hf857d28_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/cffi-1.17.0-py312hf857d28_1.conda
-  sha256: b416ece3415558013787dd70e79ef32d95688ce949a663c7801511c3abffaf7b
-  md5: 7c2757c9333c645cb6658e8eba57c8d8
-  depends:
-  - __osx >=10.13
-  - libffi >=3.4,<4.0a0
-  - pycparser
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  license: MIT
-  license_family: MIT
-  size: 281544
-  timestamp: 1724956441388
+  size: 302115
+  timestamp: 1725560701719
 - kind: pypi
   name: click
   version: 8.1.7
@@ -1024,6 +1837,21 @@ packages:
   - colorama ; platform_system == 'Windows'
   - importlib-metadata ; python_full_version < '3.8'
   requires_python: '>=3.7'
+- kind: conda
+  name: colorama
+  version: 0.4.6
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/colorama-0.4.6-pyhd8ed1ab_0.tar.bz2
+  sha256: 2c1b2e9755ce3102bca8d69e8f26e4f087ece73f50418186aee7c74bef8e1698
+  md5: 3faab06a954c2a04039983f2c4a50d99
+  depends:
+  - python >=3.7
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 25170
+  timestamp: 1666700778190
 - kind: conda
   name: comm
   version: 0.2.2
@@ -1040,6 +1868,59 @@ packages:
   license_family: BSD
   size: 12134
   timestamp: 1710320435158
+- kind: conda
+  name: cryptography
+  version: 40.0.2
+  build: py311h507f6e9_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/cryptography-40.0.2-py311h507f6e9_0.conda
+  sha256: 2c10a11166f3199795efb6ceceb4dd4557c38f40d568df8af2b829e4597dc360
+  md5: 09ebc937e6441f174bf76ea8f3b789ce
+  depends:
+  - cffi >=1.12
+  - openssl >=3.1.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1217158
+  timestamp: 1681509482280
+- kind: conda
+  name: cryptography
+  version: 40.0.2
+  build: py311h61927ef_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/cryptography-40.0.2-py311h61927ef_0.conda
+  sha256: 2700217dfc3a48e8715d7f4e94870448a37d8e9bb25c4130e83c4807c2f1f3c3
+  md5: 724b75f84bb1b5d932627d090a527168
+  depends:
+  - cffi >=1.12
+  - openssl >=3.1.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1236179
+  timestamp: 1681509343764
+- kind: conda
+  name: cryptography
+  version: 40.0.2
+  build: py311h9b4c7bb_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/cryptography-40.0.2-py311h9b4c7bb_0.conda
+  sha256: e0f62e90e664ce33054c7839ee10a975e0a80010c2691e99679319f60decca9f
+  md5: 4df4df92db0b9168c11b72460baec870
+  depends:
+  - cffi >=1.12
+  - libgcc-ng >=12
+  - openssl >=3.1.0,<4.0a0
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: Apache-2.0 AND BSD-3-Clause AND PSF-2.0 AND MIT
+  license_family: BSD
+  size: 1580501
+  timestamp: 1681508893845
 - kind: conda
   name: curl
   version: 8.8.0
@@ -1181,6 +2062,21 @@ packages:
   sha256: a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a
   requires_dist:
   - packaging
+- kind: conda
+  name: distro
+  version: 1.8.0
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/distro-1.8.0-pyhd8ed1ab_0.conda
+  sha256: 0d01c4da6d4f0a935599210f82ac0630fa9aeb4fc37cbbc78043a932a39ec4f3
+  md5: 67999c5465064480fa8016d00ac768f6
+  depends:
+  - python >=3.6
+  license: Apache-2.0
+  license_family: APACHE
+  size: 40854
+  timestamp: 1675116355989
 - kind: pypi
   name: dnspython
   version: 2.6.1
@@ -1206,6 +2102,52 @@ packages:
   - trio>=0.23 ; extra == 'trio'
   - wmi>=1.5.1 ; extra == 'wmi'
   requires_python: '>=3.8'
+- kind: conda
+  name: docutils
+  version: '0.19'
+  build: py311h267d04e_1
+  build_number: 1
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/docutils-0.19-py311h267d04e_1.tar.bz2
+  sha256: e6e04b96cbfc40303d08e63f2c0a3a2c9c47704360fb77fc1385121249294387
+  md5: 0db0a38a4d71859f2629b0811c613210
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  size: 975156
+  timestamp: 1666755185967
+- kind: conda
+  name: docutils
+  version: '0.19'
+  build: py311h38be061_1
+  build_number: 1
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/docutils-0.19-py311h38be061_1.tar.bz2
+  sha256: ec7760e5a1d065b97ac32d12f7c70f19937040d8bb52a9f16573b65c6832c67a
+  md5: 599159b0740e9b82e7eef0e8471be3c2
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  size: 977628
+  timestamp: 1666754970660
+- kind: conda
+  name: docutils
+  version: '0.19'
+  build: py311h6eed73b_1
+  build_number: 1
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/docutils-0.19-py311h6eed73b_1.tar.bz2
+  sha256: 3dde82219d807a1538464698ca1863f658a39d31a85e6bfa26ef20584617ffd4
+  md5: 268664c5447607a94cd67a0be91f83cd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: LicenseRef-Public-Domain-Dedictation and BSD-2-Clause and LicenseRef-PSF-2.1.1 and GPL-3.0-or-later
+  size: 973200
+  timestamp: 1666755137227
 - kind: pypi
   name: email-validator
   version: 2.2.0
@@ -1494,44 +2436,12 @@ packages:
   - hyperframe<7,>=6.0
   - hpack<5,>=4.0
   requires_python: '>=3.6.1'
-- kind: conda
-  name: h2
-  version: 4.1.0
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/h2-4.1.0-pyhd8ed1ab_0.tar.bz2
-  sha256: bfc6a23849953647f4e255c782e74a0e18fe16f7e25c7bb0bc57b83bb6762c7a
-  md5: b748fbf7060927a6e82df7cb5ee8f097
-  depends:
-  - hpack >=4.0,<5
-  - hyperframe >=6.0,<7
-  - python >=3.6.1
-  license: MIT
-  license_family: MIT
-  size: 46754
-  timestamp: 1634280590080
 - kind: pypi
   name: hpack
   version: 4.0.0
   url: https://files.pythonhosted.org/packages/d5/34/e8b383f35b77c402d28563d2b8f83159319b509bc5f760b15d60b0abf165/hpack-4.0.0-py3-none-any.whl
   sha256: 84a076fad3dc9a9f8063ccb8041ef100867b1878b25ef0ee63847a5d53818a6c
   requires_python: '>=3.6.1'
-- kind: conda
-  name: hpack
-  version: 4.0.0
-  build: pyh9f0ad1d_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/hpack-4.0.0-pyh9f0ad1d_0.tar.bz2
-  sha256: 5dec948932c4f740674b1afb551223ada0c55103f4c7bf86a110454da3d27cb8
-  md5: 914d6646c4dbb1fd3ff539830a12fd71
-  depends:
-  - python
-  license: MIT
-  license_family: MIT
-  size: 25341
-  timestamp: 1598856368685
 - kind: pypi
   name: httpcore
   version: 1.0.5
@@ -1594,21 +2504,6 @@ packages:
   url: https://files.pythonhosted.org/packages/d7/de/85a784bcc4a3779d1753a7ec2dee5de90e18c7bcf402e71b51fcf150b129/hyperframe-6.0.1-py3-none-any.whl
   sha256: 0ec6bafd80d8ad2195c4f03aacba3a8265e57bc4cff261e802bf39970ed02a15
   requires_python: '>=3.6.1'
-- kind: conda
-  name: hyperframe
-  version: 6.0.1
-  build: pyhd8ed1ab_0
-  subdir: noarch
-  noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.0.1-pyhd8ed1ab_0.tar.bz2
-  sha256: e374a9d0f53149328134a8d86f5d72bca4c6dcebed3c0ecfa968c02996289330
-  md5: 9f765cbfab6870c8435b9eefecd7a1f4
-  depends:
-  - python >=3.6
-  license: MIT
-  license_family: MIT
-  size: 14646
-  timestamp: 1619110249723
 - kind: pypi
   name: idna
   version: '3.7'
@@ -2345,6 +3240,55 @@ packages:
   purls: []
   size: 63655
   timestamp: 1710362424980
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: h5888daf_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.6.3-h5888daf_0.conda
+  sha256: 4bb47bb2cd09898737a5211e2992d63c555d63715a07ba56eae0aff31fb89c22
+  md5: 59f4c43bb1b5ef1c71946ff2cbf59524
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=13
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 73616
+  timestamp: 1725568742634
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: hac325c4_0
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.6.3-hac325c4_0.conda
+  sha256: dd22dffad6731c352f4c14603868c9cce4d3b50ff5ff1e50f416a82dcb491947
+  md5: c1db99b0a94a2f23bd6ce39e2d314e07
+  depends:
+  - __osx >=10.13
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 70517
+  timestamp: 1725568864316
+- kind: conda
+  name: libexpat
+  version: 2.6.3
+  build: hf9b8971_0
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.6.3-hf9b8971_0.conda
+  sha256: 5cbe5a199fba14ade55457a468ce663aac0b54832c39aa54470b3889b4c75c4a
+  md5: 5f22f07c2ab2dea8c66fe9585a062c96
+  depends:
+  - __osx >=11.0
+  constrains:
+  - expat 2.6.3.*
+  license: MIT
+  license_family: MIT
+  size: 63895
+  timestamp: 1725568783033
 - kind: conda
   name: libffi
   version: 3.4.2
@@ -3463,6 +4407,24 @@ packages:
   requires_python: '>=3.8,<4.0'
 - kind: conda
   name: prompt-toolkit
+  version: 3.0.38
+  build: pyha770c72_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt-toolkit-3.0.38-pyha770c72_0.conda
+  sha256: 78c2f3c6195ec350d7d6e5fa3e43274ca8191c181c97a867e2920faaeec0e9bc
+  md5: 59ba1bf8ea558751a0d391249a248765
+  depends:
+  - python >=3.7
+  - wcwidth
+  constrains:
+  - prompt_toolkit 3.0.38
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 269375
+  timestamp: 1677601102637
+- kind: conda
+  name: prompt-toolkit
   version: 3.0.47
   build: pyha770c72_0
   subdir: noarch
@@ -3479,6 +4441,21 @@ packages:
   license_family: BSD
   size: 270710
   timestamp: 1718048095491
+- kind: conda
+  name: prompt_toolkit
+  version: 3.0.38
+  build: hd8ed1ab_0
+  subdir: noarch
+  noarch: generic
+  url: https://conda.anaconda.org/conda-forge/noarch/prompt_toolkit-3.0.38-hd8ed1ab_0.conda
+  sha256: c0f24a75d27918eb33f86902aa6024783d128a89eb3a169bcb22f24163a422b3
+  md5: 45b74f64d8808eda7e6f6e6b1d641fd2
+  depends:
+  - prompt-toolkit >=3.0.38,<3.0.39.0a0
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6402
+  timestamp: 1677601110741
 - kind: conda
   name: psutil
   version: 6.0.0
@@ -3638,6 +4615,22 @@ packages:
   size: 879295
   timestamp: 1714846885370
 - kind: conda
+  name: pyopenssl
+  version: 23.1.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/pyopenssl-23.1.1-pyhd8ed1ab_0.conda
+  sha256: 458428cb867f70f2af2a4ed59d382291ea3eb3f10490196070a15d1d71d5432a
+  md5: 0b34aa3ab7e7ccb1765a03dd9ed29938
+  depends:
+  - cryptography >=38.0.0,<41
+  - python >=3.6
+  license: Apache-2.0
+  license_family: Apache
+  size: 128079
+  timestamp: 1680037561734
+- kind: conda
   name: pysocks
   version: 1.7.1
   build: pyha2e5f31_6
@@ -3654,6 +4647,89 @@ packages:
   license_family: BSD
   size: 18981
   timestamp: 1661604969727
+- kind: conda
+  name: python
+  version: 3.11.10
+  build: h739c21a_0_cpython
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.11.10-h739c21a_0_cpython.conda
+  sha256: c7a8698fff5e8b451c3168c14f2f3bf340d523cb8b197aacad9e890e4851df4d
+  md5: ec064c104aa080f5e5e4c159d8e8fed0
+  depends:
+  - __osx >=11.0
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 14524339
+  timestamp: 1725966089506
+- kind: conda
+  name: python
+  version: 3.11.10
+  build: h8f8b54e_0_cpython
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.11.10-h8f8b54e_0_cpython.conda
+  sha256: 3a1b985bf971cc5f6bfcfea97b1daa99e652ddf0c27a889f65cb5996c0276de7
+  md5: 35939f164fd23daa0d245675d7a4f8d9
+  depends:
+  - __osx >=10.13
+  - bzip2 >=1.0.8,<2.0a0
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 15491264
+  timestamp: 1725966701771
+- kind: conda
+  name: python
+  version: 3.11.10
+  build: hc5c86c4_0_cpython
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.11.10-hc5c86c4_0_cpython.conda
+  sha256: 844bb9cefdfe93969fd9a9b593f6eb1ecbe6c53ab8d1a5d441bd7c93b31d0fef
+  md5: 43a02ff0a2dafe8a8a1b6a9eacdbd2cc
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - bzip2 >=1.0.8,<2.0a0
+  - ld_impl_linux-64 >=2.36.1
+  - libexpat >=2.6.3,<3.0a0
+  - libffi >=3.4,<4.0a0
+  - libgcc >=13
+  - libnsl >=2.0.1,<2.1.0a0
+  - libsqlite >=3.46.1,<4.0a0
+  - libuuid >=2.38.1,<3.0a0
+  - libxcrypt >=4.4.36
+  - libzlib >=1.3.1,<2.0a0
+  - ncurses >=6.5,<7.0a0
+  - openssl >=3.3.2,<4.0a0
+  - readline >=8.2,<9.0a0
+  - tk >=8.6.13,<8.7.0a0
+  - tzdata
+  - xz >=5.2.6,<6.0a0
+  constrains:
+  - python_abi 3.11.* *_cp311
+  license: Python-2.0
+  size: 30607461
+  timestamp: 1725967457875
 - kind: conda
   name: python
   version: 3.12.5
@@ -3795,6 +4871,51 @@ packages:
   requires_python: '>=3.8'
 - kind: conda
   name: python_abi
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.11-5_cp311.conda
+  sha256: 2660b8059b3ee854bc5d3c6b1fce946e5bd2fe8fbca7827de2c5885ead6209de
+  md5: 139a8d40c8a2f430df31048949e450de
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6211
+  timestamp: 1723823324668
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.11-5_cp311.conda
+  sha256: 9b092850a268aca99600b724bae849f51209ecd5628e609b4699debc59ff1945
+  md5: e6d62858c06df0be0e6255c753d74787
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6303
+  timestamp: 1723823062672
+- kind: conda
+  name: python_abi
+  version: '3.11'
+  build: 5_cp311
+  build_number: 5
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.11-5_cp311.conda
+  sha256: adc05729b7e0aca7b436e60a86f10822a92185dfcb48d66d6444e3629d3a1f6a
+  md5: 3b855e3734344134cb56c410f729c340
+  constrains:
+  - python 3.11.* *_cpython
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 6308
+  timestamp: 1723823096865
+- kind: conda
+  name: python_abi
   version: '3.12'
   build: 4_cp312
   build_number: 4
@@ -3841,51 +4962,6 @@ packages:
   purls: []
   size: 6508
   timestamp: 1695147497048
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
-  build_number: 5
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/python_abi-3.12-5_cp312.conda
-  sha256: d10e93d759931ffb6372b45d65ff34d95c6000c61a07e298d162a3bc2accebb0
-  md5: 0424ae29b104430108f5218a66db7260
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6238
-  timestamp: 1723823388266
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
-  build_number: 5
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/python_abi-3.12-5_cp312.conda
-  sha256: 4da26c7508d5bc5d8621e84dc510284402239df56aab3587a7d217de9d3c806d
-  md5: c34dd4920e0addf7cfcc725809f25d8e
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6312
-  timestamp: 1723823137004
-- kind: conda
-  name: python_abi
-  version: '3.12'
-  build: 5_cp312
-  build_number: 5
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python_abi-3.12-5_cp312.conda
-  sha256: 49d624e4b809c799d2bf257b22c23cf3fc4460f5570d9a58e7ad86350aeaa1f4
-  md5: b76f9b1c862128e56ac7aa8cd2333de9
-  constrains:
-  - python 3.12.* *_cpython
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 6278
-  timestamp: 1723823099686
 - kind: pypi
   name: pyyaml
   version: 6.0.2
@@ -4052,6 +5128,112 @@ packages:
   size: 184347
   timestamp: 1709150578093
 - kind: conda
+  name: ruamel.yaml
+  version: 0.17.21
+  build: py311h2582759_3
+  build_number: 3
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml-0.17.21-py311h2582759_3.conda
+  sha256: bbf5aff9519226e7cf98a7df4b4d0b0de97991c64515a6ddcaca91d4c822226e
+  md5: d47e33b1053996205f29896708c91a3d
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml.clib >=0.1.2
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 259873
+  timestamp: 1678273124540
+- kind: conda
+  name: ruamel.yaml
+  version: 0.17.21
+  build: py311h5547dcb_3
+  build_number: 3
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml-0.17.21-py311h5547dcb_3.conda
+  sha256: 3a049c90ccd277151ec2cf2a4fb169e794d6780c22830bf4b50431e35bded7e5
+  md5: da5e0f0b7d5db68eb540cde291027995
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml.clib >=0.1.2
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 260543
+  timestamp: 1678273295515
+- kind: conda
+  name: ruamel.yaml
+  version: 0.17.21
+  build: py311he2be06e_3
+  build_number: 3
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml-0.17.21-py311he2be06e_3.conda
+  sha256: 01a5e068e125b71e85e732f0e449296592881e74a7718d21cde3f4c9cf35d215
+  md5: c964b671afc5b881fc3e20e5db12bf46
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  - ruamel.yaml.clib >=0.1.2
+  - setuptools
+  license: MIT
+  license_family: MIT
+  size: 260384
+  timestamp: 1678273424672
+- kind: conda
+  name: ruamel.yaml.clib
+  version: 0.2.7
+  build: py311h2725bcf_2
+  build_number: 2
+  subdir: osx-64
+  url: https://conda.anaconda.org/conda-forge/osx-64/ruamel.yaml.clib-0.2.7-py311h2725bcf_2.conda
+  sha256: b529c2caf941ac1050d160f0b9c53202d634954dd7cc7f1469731e1bb6f2cccc
+  md5: cd953388469a8890dda83779d6ef6ffd
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 117447
+  timestamp: 1695997294294
+- kind: conda
+  name: ruamel.yaml.clib
+  version: 0.2.7
+  build: py311h459d7ec_2
+  build_number: 2
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.7-py311h459d7ec_2.conda
+  sha256: cfd060725d39f136618547ecb8a593d82d460725fb447849815c26418c360c35
+  md5: 56bc3fe5180c0b23e05c7a5708153ac7
+  depends:
+  - libgcc-ng >=12
+  - python >=3.11,<3.12.0a0
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 134322
+  timestamp: 1695997009048
+- kind: conda
+  name: ruamel.yaml.clib
+  version: 0.2.7
+  build: py311heffc1b2_2
+  build_number: 2
+  subdir: osx-arm64
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ruamel.yaml.clib-0.2.7-py311heffc1b2_2.conda
+  sha256: 0c2d1a27afa009d3630b5944ac5fd10df95b92ab5c91c7390ddfc93ee5488349
+  md5: c167b931a12c70f9c1fbf927da7ff0be
+  depends:
+  - python >=3.11,<3.12.0a0
+  - python >=3.11,<3.12.0a0 *_cpython
+  - python_abi 3.11.* *_cp311
+  license: MIT
+  license_family: MIT
+  size: 113666
+  timestamp: 1695997356455
+- kind: conda
   name: ruby
   version: 3.3.3
   build: h3da8d8b_0
@@ -4136,6 +5318,21 @@ packages:
   size: 9122092
   timestamp: 1719568095402
 - kind: conda
+  name: s2n
+  version: 1.4.0
+  build: h06160fa_0
+  subdir: linux-64
+  url: https://conda.anaconda.org/conda-forge/linux-64/s2n-1.4.0-h06160fa_0.conda
+  sha256: f6cc2bdcb5d809bbaae218e03bdefef4a309d1fc7ccc9444fda59bd4553a83f8
+  md5: 3d1b58d2664d96f9fbc0afe5e1d04632
+  depends:
+  - libgcc-ng >=12
+  - openssl >=3.2.0,<4.0a0
+  license: Apache-2.0
+  license_family: Apache
+  size: 329669
+  timestamp: 1701891861649
+- kind: conda
   name: s3transfer
   version: 0.10.2
   build: pyhd8ed1ab_0
@@ -4168,6 +5365,21 @@ packages:
   - pkg:pypi/setuptools?source=compressed-mapping
   size: 1462612
   timestamp: 1722586785703
+- kind: conda
+  name: setuptools
+  version: 73.0.1
+  build: pyhd8ed1ab_0
+  subdir: noarch
+  noarch: python
+  url: https://conda.anaconda.org/conda-forge/noarch/setuptools-73.0.1-pyhd8ed1ab_0.conda
+  sha256: c9f5e110e3fe5a7c4cd5b9da445c05a1fae000b43ab3a97cb6a501f4267515fc
+  md5: f0b618d7673d1b2464f600b34d912f6f
+  depends:
+  - python >=3.8
+  license: MIT
+  license_family: MIT
+  size: 1460460
+  timestamp: 1725348602179
 - kind: pypi
   name: shellingham
   version: 1.5.4
@@ -4595,24 +5807,21 @@ packages:
   timestamp: 1724736371498
 - kind: conda
   name: urllib3
-  version: 2.2.2
-  build: pyhd8ed1ab_1
-  build_number: 1
+  version: 1.26.19
+  build: pyhd8ed1ab_0
   subdir: noarch
   noarch: python
-  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.2.2-pyhd8ed1ab_1.conda
-  sha256: 00c47c602c03137e7396f904eccede8cc64cc6bad63ce1fc355125df8882a748
-  md5: e804c43f58255e977093a2298e442bb8
+  url: https://conda.anaconda.org/conda-forge/noarch/urllib3-1.26.19-pyhd8ed1ab_0.conda
+  sha256: 543ebab5241418a4e0d4d9e356ef13e4361504810a067a01481660bb35eb5643
+  md5: 6bb37c314b3cc1515dcf086ffe01c46e
   depends:
   - brotli-python >=1.0.9
-  - h2 >=4,<5
   - pysocks >=1.5.6,<2.0,!=1.5.7
-  - python >=3.8
-  - zstandard >=0.18.0
+  - python >=3.7
   license: MIT
   license_family: MIT
-  size: 95048
-  timestamp: 1719391384778
+  size: 115125
+  timestamp: 1718728467518
 - kind: pypi
   name: uvicorn
   version: 0.30.6
@@ -4906,68 +6115,6 @@ packages:
   license_family: MIT
   size: 20857
   timestamp: 1723591347715
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py312h15fbf35_1
-  build_number: 1
-  subdir: osx-arm64
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstandard-0.23.0-py312h15fbf35_1.conda
-  sha256: d00ca25c1e28fd31199b26a94f8c96574475704a825d244d7a6351ad3745eeeb
-  md5: a4cde595509a7ad9c13b1a3809bcfe51
-  depends:
-  - __osx >=11.0
-  - cffi >=1.11
-  - python >=3.12,<3.13.0a0
-  - python >=3.12,<3.13.0a0 *_cpython
-  - python_abi 3.12.* *_cp312
-  - zstd >=1.5.6,<1.5.7.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 330788
-  timestamp: 1725305806565
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py312h7122b0e_1
-  build_number: 1
-  subdir: osx-64
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstandard-0.23.0-py312h7122b0e_1.conda
-  sha256: 2685dde42478fae0780fba5d1f8a06896a676ae105f215d32c9f9e76f3c6d8fd
-  md5: bd132ba98f3fc0a6067f355f8efe4cb6
-  depends:
-  - __osx >=10.13
-  - cffi >=1.11
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - zstd >=1.5.6,<1.5.7.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 410873
-  timestamp: 1725305688706
-- kind: conda
-  name: zstandard
-  version: 0.23.0
-  build: py312hef9b889_1
-  build_number: 1
-  subdir: linux-64
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstandard-0.23.0-py312hef9b889_1.conda
-  sha256: b97015e146437283f2213ff0e95abdc8e2480150634d81fbae6b96ee09f5e50b
-  md5: 8b7069e9792ee4e5b4919a7a306d2e67
-  depends:
-  - __glibc >=2.17,<3.0.a0
-  - cffi >=1.11
-  - libgcc >=13
-  - python >=3.12,<3.13.0a0
-  - python_abi 3.12.* *_cp312
-  - zstd >=1.5.6,<1.5.7.0a0
-  - zstd >=1.5.6,<1.6.0a0
-  license: BSD-3-Clause
-  license_family: BSD
-  size: 419552
-  timestamp: 1725305670210
 - kind: conda
   name: zstd
   version: 1.5.6

--- a/pixi.toml
+++ b/pixi.toml
@@ -152,6 +152,8 @@ depends-on = ["install-flutter"]
 python = ">=3.10"
 opentofu = ">=1.8.1"
 boto3 = ">=1.35"
+awscli = ">=2.4.0"
+aws-session-manager-plugin = ">=1.2.0"
 
 # OpenTofu tasks
 [feature.cloud.tasks.cloud-deploy]

--- a/pixi.toml
+++ b/pixi.toml
@@ -176,3 +176,6 @@ cmd = "python scripts/run-cloud-server.py --scale-up"
 
 [feature.cloud.tasks.cloud-server-stop]
 cmd = "python scripts/run-cloud-server.py --scale-down"
+
+[feature.cloud.tasks.cloud-server-access]
+cmd = "scripts/access-cloud-server.sh"

--- a/scripts/access-cloud-server.sh
+++ b/scripts/access-cloud-server.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+function sanitize() {
+    echo $1 |  tr '[:upper:]' '[:lower:]' | tr -d ' '
+}
+
+export project=$(sanitize "$TF_VAR_project_name")
+export neighborhood=$(sanitize "$TF_VAR_neighborhood")
+
+echo "Sourcing credentials"
+
+export sts_output=$(aws sts assume-role \
+--role-arn arn:aws:iam::871683513797:role/$project-$neighborhood-server-access-role \
+--role-session-name access-cloud-server \
+--output json \
+)
+
+export AWS_ACCESS_KEY_ID=$(echo $sts_output | jq -r ".Credentials.AccessKeyId")
+export AWS_SECRET_ACCESS_KEY=$(echo $sts_output | jq -r ".Credentials.SecretAccessKey")
+export AWS_SESSION_TOKEN=$(echo $sts_output | jq -r ".Credentials.SessionToken")
+
+echo "Getting instance ID"
+
+export instance_id=$(aws ec2 describe-instances \
+--region us-west-2 \
+--filters Name=tag:Project,Values='Support Sphere' \
+Name=instance-state-name,Values=running \
+--query "Reservations[*].Instances[*].[InstanceId]" \
+--output text \
+)
+
+if [[ -z $instance_id ]]; then
+    echo "No running instances found."
+    echo "You can start the server by running the following command:"
+    echo "   pixi run cloud-server-run"
+    echo "Then try this script again."
+    echo "If you've already started a server, it can take a few minutes for it to be ready to accept connections."
+    echo "Exiting..."
+    exit 1
+fi
+
+echo "Starting session with instance $instance_id"
+
+aws ssm start-session \
+--document-name AWS-StartInteractiveCommand \
+--parameters command="cd /opt/post-disaster-comms && bash -l" \
+--target $instance_id

--- a/scripts/access-cloud-server.sh
+++ b/scripts/access-cloud-server.sh
@@ -43,5 +43,5 @@ echo "Starting session with instance $instance_id"
 
 aws ssm start-session \
 --document-name AWS-StartInteractiveCommand \
---parameters command="cd /opt/post-disaster-comms && bash -l" \
+--parameters command="cd ~ && bash -l" \
 --target $instance_id


### PR DESCRIPTION
Output when there's a server running:

```
$ pixi run cloud-server-access
✨ Pixi task (cloud-server-access in deployment): scripts/access-cloud-server.sh
Sourcing credentials
Getting instance ID
Starting session with instance i-09982f5725ab6be9b

Starting session with SessionId: access-cloud-server-adpal33o3qu5pk44cfndbtweca
ssm-user@ip-10-0-101-24:~$
```

Output when there's no server running:

```
$ pixi run cloud-server-access
✨ Pixi task (cloud-server-access in deployment): scripts/access-cloud-server.sh
Sourcing credentials
Getting instance ID
No running instances found.
You can start the server by running the following command:
   pixi run cloud-server-run
Then try this script again.
If you've already started a server, it can take a few minutes for it to be ready to accept connections.
Exiting...
```

Want to test this on my windows laptop and see if it works even a lil bit

---

resolves: #64