### PR TITLE
build: Store OpenTofu state in S3 to enable devs on multiple machines to stay in sync

### DIFF
--- a/deployment/cloud/main.tf
+++ b/deployment/cloud/main.tf
@@ -5,6 +5,12 @@ terraform {
       version = "~> 5.61"
     }
   }
+
+  backend "s3" {
+    bucket = "${local.resource_prefix}-${var.account_id}-opentofu-state"
+    key = "infrastructure/${var.stage}/terraform.tfstate"
+    region = "us-west-2"
+  }
 }
 
 locals {

--- a/deployment/cloud/variables.tf
+++ b/deployment/cloud/variables.tf
@@ -18,6 +18,11 @@ variable "stage" {
     }
 }
 
+variable "account_id" {
+    description = "The AWS account ID"
+    type        = string
+}
+
 variable "additional_tags" {
     description = "Additional tags to apply to resources"
     type        = map(string)

--- a/pixi.toml
+++ b/pixi.toml
@@ -166,6 +166,7 @@ depends-on = ["install-flutter"]
 "TF_VAR_project_name" = "Support Sphere"
 "TF_VAR_neighborhood" = "Laurelhurst"
 "TF_VAR_stage" = "dev"
+"TF_VAR_account_id" = "871683513797"
 
 [feature.cloud.tasks]
 # empty for now


### PR DESCRIPTION
Ran into an issue where I had accidentally deleted my local `terraform.tfstate` file, which associates actual AWS resource names with their OpenTofu definitions. The `terraform.tfstate` file was in the `.gitignore` since I had misinterpreted advice given on whether or not to add these files to VCS, so I had to go in and manually rebuild associations for all 35 resources.

To avoid this, I've made the changes in this PR, which write and read the expected state files into an s3 bucket (which I'm adding definitions to create in the account setup template), which will prevent these kinds of issues in the future. More info on this can be found here: https://opentofu.org/docs/language/settings/backends/s3/

Nobody should have to rebuild that state by hand, it's very much not fun 🫠 