### PR TITLE
feat: Add app pages skeleton for navigating to other pages

### DIFF
--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -1,0 +1,27 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:ionicons/ionicons.dart';
+
+class AppRoute extends Equatable {
+  const AppRoute({required this.icon, required this.label, this.body});
+
+  final Icon icon;
+  final String label;
+  final Widget? body;
+
+  @override
+  List<Object?> get props => [icon, label, body];
+}
+
+class AppNavigation {
+  // TODO: Add body for each route
+  static List<AppRoute> destinations = [
+    const AppRoute(
+        icon: Icon(Ionicons.home_sharp), label: 'Home'),
+    const AppRoute(
+        icon: Icon(Ionicons.person_sharp), label: 'Me'),
+    const AppRoute(
+        icon: Icon(Ionicons.shield_checkmark_sharp), label: 'Prepare'),
+    const AppRoute(icon: Icon(Ionicons.hammer_sharp), label: 'Resources'),
+  ];
+}

--- a/src/support_sphere/lib/logic/bloc/app_bloc.dart
+++ b/src/support_sphere/lib/logic/bloc/app_bloc.dart
@@ -1,0 +1,16 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+part 'app_event.dart';
+part 'app_state.dart';
+
+class AppBloc extends Bloc<AppEvent, AppState> {
+  AppBloc() : super(const AppState()) {
+    on<AppOnBottomNavIndexChanged>(_onBottomNavIndexChanged);
+  }
+
+  void _onBottomNavIndexChanged(
+      AppOnBottomNavIndexChanged event, Emitter<AppState> emit) {
+    emit(state.copyWith(selectedBottomNavIndex: event.selectedBottomNavIndex));
+  }
+}

--- a/src/support_sphere/lib/logic/bloc/app_event.dart
+++ b/src/support_sphere/lib/logic/bloc/app_event.dart
@@ -1,0 +1,15 @@
+part of 'app_bloc.dart';
+
+class AppEvent extends Equatable {
+  @override
+  List<Object> get props => [];
+}
+
+class AppOnBottomNavIndexChanged extends AppEvent {
+  AppOnBottomNavIndexChanged(this.selectedBottomNavIndex);
+
+  final int selectedBottomNavIndex;
+
+  @override
+  List<Object> get props => [selectedBottomNavIndex];
+}

--- a/src/support_sphere/lib/logic/bloc/app_state.dart
+++ b/src/support_sphere/lib/logic/bloc/app_state.dart
@@ -1,0 +1,20 @@
+part of 'app_bloc.dart';
+
+class AppState extends Equatable {
+  const AppState({
+    this.selectedBottomNavIndex = 0,
+  });
+
+  final int selectedBottomNavIndex;
+
+  @override
+  List<Object> get props => [selectedBottomNavIndex];
+
+  AppState copyWith({
+    int? selectedBottomNavIndex,
+  }) {
+    return AppState(
+      selectedBottomNavIndex: selectedBottomNavIndex ?? this.selectedBottomNavIndex,
+    );
+  }
+}

--- a/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+// TODO: Activate Ionicons package when used
+// import 'package:ionicons/ionicons.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/logic/bloc/app_bloc.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:support_sphere/presentation/router/app_body_select.dart';
+
+class AppPage extends StatelessWidget {
+  const AppPage({super.key});
+
+  static MaterialPage page() => const MaterialPage(child: AppPage());
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (_) => AppBloc(),
+      child: BlocBuilder<AppBloc, AppState>(
+        buildWhen: (previous, current) =>
+            previous.selectedBottomNavIndex != current.selectedBottomNavIndex,
+        builder: (context, state) {
+          return SafeArea(
+            child: Scaffold(
+              appBar: AppBar(
+                // TODO: Add hamburger menu
+                // leading: Builder(
+                //   builder: (context) {
+                //     return IconButton(
+                //       icon: const Icon(color: Colors.white, Ionicons.menu_outline),
+                //       onPressed: () {
+                //         Scaffold.of(context).openDrawer();
+                //       },
+                //     );
+                //   },
+                // ),
+                // TODO: Change color to red during emergency mode
+                backgroundColor: Theme.of(context).colorScheme.primaryContainer,
+                // TODO: Add "Emergency Declared" title during emergency mode
+                title: const Text(
+                  AppStrings.appName,
+                  style: TextStyle(color: Colors.white),
+                ),
+                actions: const [
+                  // TODO: Add mode change button
+                  // IconButton(
+                  //   onPressed: () => showChangeModeAlert(context),
+                  //   icon: Icon(Ionicons.radio_outline),
+                  //   color: Colors.white,
+                  // ),
+                  // TODO: Add notifications badge
+                  // IconButton(
+                  //   icon: const Badge(
+                  //       label: Text('2'),
+                  //       child: Icon(Ionicons.notifications_sharp)),
+                  //   color: Colors.white,
+                  //   onPressed: () {},
+                  // ),
+                ],
+              ),
+              // TODO: Add hamburger menu navigation
+              // drawer: const Drawer(
+              //   child: null,
+              // ),
+              body: AppBodySelect.getBody(state.selectedBottomNavIndex),
+              bottomNavigationBar: NavigationBar(
+                selectedIndex: state.selectedBottomNavIndex,
+                onDestinationSelected: (value) {
+                  context
+                      .read<AppBloc>()
+                      .add(AppOnBottomNavIndexChanged(value));
+                },
+                destinations: [
+                  for (final destination in AppBodySelect.destinations)
+                    NavigationDestination(
+                      icon: destination.icon,
+                      label: destination.label,
+                    )
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/src/support_sphere/lib/presentation/router/app_body_select.dart
+++ b/src/support_sphere/lib/presentation/router/app_body_select.dart
@@ -1,0 +1,15 @@
+import 'package:equatable/equatable.dart';
+import 'package:flutter/material.dart';
+import 'package:support_sphere/constants/routes.dart';
+
+class AppBodySelect extends Equatable {
+  static final destinations = AppNavigation.destinations;
+
+  @override
+  List<Object> get props => [destinations];
+
+  static Widget getBody(int index) {
+    AppRoute collection = destinations[index];
+    return collection.body ?? Center(child: Text('${collection.label} Page Coming soon!'));
+  }
+}

--- a/src/support_sphere/lib/presentation/router/auth_select.dart
+++ b/src/support_sphere/lib/presentation/router/auth_select.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:support_sphere/logic/bloc/auth/authentication_bloc.dart';
 import 'package:support_sphere/data/repositories/authentication.dart';
+import 'package:support_sphere/presentation/pages/main_app/app_page.dart';
 import 'package:support_sphere/presentation/router/flows/onboarding_flow.dart';
 
 /// Selects the appropriate page to display based on the user's authentication status
@@ -20,8 +21,7 @@ class AuthSelect extends StatelessWidget {
           switch (authStatus) {
             case AuthenticationStatus.authenticated:
               /// If the user is authenticated, display the main app page
-              // TODO: Add the main app page here
-              return Container();
+              return const AppPage();
               // return const AppPage();
             case AuthenticationStatus.unauthenticated:
               /// If the user is not authenticated, display the onboarding flow


### PR DESCRIPTION
This PR closes #94. It sets up the App bloc for managing overall app state as well as getting the nav view to the various pages within the app together.

## Demo

<img width="1496" alt="Screenshot 2024-09-25 at 8 56 30 AM" src="https://github.com/user-attachments/assets/3de54d6d-e191-49f2-9914-2466665b621e">
