### PR TITLE
feat: Add app mode operational status logic

### DIFF
--- a/deployment/values.dev.yaml
+++ b/deployment/values.dev.yaml
@@ -83,6 +83,10 @@ rest:
     tag: 2024.09.13
 
 realtime:
+  # Override the fullname of the realtime deployment
+  # as this is needed by supabase realtime to work properly
+  # See: https://github.com/supabase-community/supabase-kubernetes/issues/74
+  fullnameOverride: "realtime-dev"
   imagePullSecrets:
   - name: regcred
   image:

--- a/src/support_sphere/lib/data/models/operational_event.dart
+++ b/src/support_sphere/lib/data/models/operational_event.dart
@@ -1,0 +1,32 @@
+import 'package:equatable/equatable.dart';
+import 'package:support_sphere/logic/bloc/app_bloc.dart';
+
+class OperationalEvent extends Equatable {
+  const OperationalEvent({
+    required this.id,
+    required this.createdBy,
+    required this.createdAt,
+    required this.operationalStatus,
+  });
+
+  final String id;
+  final String createdBy;
+  final String createdAt;
+  final String operationalStatus;
+
+  @override
+  List<Object?> get props => [id, createdBy, createdAt, operationalStatus];
+
+  AppModes get appMode {
+    switch (operationalStatus) {
+      case 'NORMAL':
+        return AppModes.normal;
+      case 'EMERGENCY':
+        return AppModes.emergency;
+      case 'TEST':
+        return AppModes.testEmergency;
+      default:
+        return AppModes.normal;
+    }
+  }
+}

--- a/src/support_sphere/lib/data/repositories/app.dart
+++ b/src/support_sphere/lib/data/repositories/app.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+import 'package:support_sphere/data/models/operational_event.dart';
+import 'package:support_sphere/utils/supabase.dart';
+import 'package:uuid/v4.dart';
+
+class AppRepository {
+  final _supabaseClient = supabase;
+
+  Future<void> changeOperationalStatus({
+    required String? operationalStatus,
+  }) async {
+    print("Changing operational status to $operationalStatus");
+    await _supabaseClient.from('operational_events').insert({
+      'id': const UuidV4().generate(),
+      'created_by': _supabaseClient.auth.currentUser!.id,
+      'created_at': DateTime.now().toIso8601String(),
+      'status': operationalStatus,
+    });
+  }
+
+  Stream<OperationalEvent> get operationalStatus {
+    return _supabaseClient
+        .from('operational_events')
+        .stream(primaryKey: ['id'])
+        .order('created_at', ascending: false)
+        .limit(1)
+        .map((data) {
+          Map<String, dynamic> record = data[0];
+          // Parse the data into a OperationalEvent object
+          OperationalEvent event = OperationalEvent(
+            id: record['id'],
+            createdBy: record['created_by'],
+            createdAt: record['created_at'],
+            operationalStatus: record['status'],
+          );
+          return event;
+        });
+  }
+}

--- a/src/support_sphere/lib/logic/bloc/app_bloc.dart
+++ b/src/support_sphere/lib/logic/bloc/app_bloc.dart
@@ -7,6 +7,11 @@ part 'app_state.dart';
 class AppBloc extends Bloc<AppEvent, AppState> {
   AppBloc() : super(const AppState()) {
     on<AppOnBottomNavIndexChanged>(_onBottomNavIndexChanged);
+    on<AppOnModeChanged>(_onModeChanged);
+  }
+
+  void _onModeChanged(AppOnModeChanged event, Emitter<AppState> emit) {
+    emit(state.copyWith(mode: event.mode));
   }
 
   void _onBottomNavIndexChanged(

--- a/src/support_sphere/lib/logic/bloc/app_bloc.dart
+++ b/src/support_sphere/lib/logic/bloc/app_bloc.dart
@@ -1,21 +1,45 @@
+import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:support_sphere/data/models/operational_event.dart';
+import 'package:support_sphere/data/repositories/app.dart';
 
 part 'app_event.dart';
 part 'app_state.dart';
 
 class AppBloc extends Bloc<AppEvent, AppState> {
-  AppBloc() : super(const AppState()) {
+  AppBloc({required AppRepository appRepository})
+      : _appRepository = appRepository,
+        super(const AppState()) {
     on<AppOnBottomNavIndexChanged>(_onBottomNavIndexChanged);
     on<AppOnModeChanged>(_onModeChanged);
+    on<AppOnStatusChangeRequested>(_updateStatus);
+
+    _operationalStatusSubscription = _appRepository.operationalStatus.listen(
+      (data) => add(AppOnModeChanged(data.appMode)),
+    );
   }
+
+  final AppRepository _appRepository;
+  late final StreamSubscription<OperationalEvent>
+      _operationalStatusSubscription;
 
   void _onModeChanged(AppOnModeChanged event, Emitter<AppState> emit) {
     emit(state.copyWith(mode: event.mode));
   }
 
+  void _updateStatus(AppOnStatusChangeRequested event, Emitter<AppState> emit) {
+    _appRepository.changeOperationalStatus(operationalStatus: event.mode.name);
+  }
+
   void _onBottomNavIndexChanged(
       AppOnBottomNavIndexChanged event, Emitter<AppState> emit) {
     emit(state.copyWith(selectedBottomNavIndex: event.selectedBottomNavIndex));
+  }
+
+  @override
+  Future<void> close() {
+    _operationalStatusSubscription.cancel();
+    return super.close();
   }
 }

--- a/src/support_sphere/lib/logic/bloc/app_event.dart
+++ b/src/support_sphere/lib/logic/bloc/app_event.dart
@@ -5,6 +5,24 @@ class AppEvent extends Equatable {
   List<Object> get props => [];
 }
 
+class AppOnModeChanged extends AppEvent {
+  AppOnModeChanged(this.mode);
+
+  final AppModes mode;
+
+  @override
+  List<Object> get props => [mode];
+}
+
+class AppOnStatusChangeRequested extends AppEvent {
+  AppOnStatusChangeRequested(this.mode);
+
+  final AppModes mode;
+
+  @override
+  List<Object> get props => [mode];
+}
+
 class AppOnBottomNavIndexChanged extends AppEvent {
   AppOnBottomNavIndexChanged(this.selectedBottomNavIndex);
 

--- a/src/support_sphere/lib/logic/bloc/app_state.dart
+++ b/src/support_sphere/lib/logic/bloc/app_state.dart
@@ -1,19 +1,29 @@
 part of 'app_bloc.dart';
 
+enum AppModes {
+  normal,
+  emergency,
+  testEmergency,
+}
+
 class AppState extends Equatable {
   const AppState({
+    this.mode = AppModes.normal,
     this.selectedBottomNavIndex = 0,
   });
 
+  final AppModes mode;
   final int selectedBottomNavIndex;
 
   @override
-  List<Object> get props => [selectedBottomNavIndex];
+  List<Object> get props => [mode, selectedBottomNavIndex];
 
   AppState copyWith({
+    AppModes? mode,
     int? selectedBottomNavIndex,
   }) {
     return AppState(
+      mode: mode ?? this.mode,
       selectedBottomNavIndex: selectedBottomNavIndex ?? this.selectedBottomNavIndex,
     );
   }

--- a/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 // TODO: Activate Ionicons package when used
 // import 'package:ionicons/ionicons.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/data/repositories/app.dart';
 import 'package:support_sphere/logic/bloc/app_bloc.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:support_sphere/presentation/router/app_body_select.dart';
@@ -14,7 +15,7 @@ class AppPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => AppBloc(),
+      create: (_) => AppBloc(appRepository: AppRepository()),
       child: BlocBuilder<AppBloc, AppState>(
         buildWhen: (previous, current) =>
             previous.selectedBottomNavIndex != current.selectedBottomNavIndex,


### PR DESCRIPTION
This PR depends on #95. It adds an additional state attribute for `AppState` called `mode`. This is meant to keep track of the `operational_status` of the app. There are 3 operational status of `emergency`, `normal`, and `test` mode. This PR relates to #27.