### PR TITLE
feat: Integrate emergency button with the backend

### DIFF
--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -27,4 +27,11 @@ class ErrorMessageStrings {
   static const String invalidSignUpCode = 'Invalid sign up code';
 }
 
+/// App Modes Strings
+class AppModes {
+  static const String normal = 'NORMAL';
+  static const String emergency = 'EMERGENCY';
+  static const String testEmergency = 'TEST';
+}
+
 

--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -4,6 +4,21 @@ class AppStrings {
   static const String signUpWelcome = 'Welcome to ${AppStrings.appName}\nCreate a new account and prepare with your community';
 }
 
+class EmergencyAlertDialogStrings {
+  static const String title = 'Emergency Declared';
+  static const String message = 'An emergency has been declared.\nWould you like to return to normal mode?';
+  static const String buttonYes = 'Yes';
+  static const String buttonNo = 'No';
+}
+
+class NormalAlertDialogStrings {
+  static const String title = 'Declare An Emergency';
+  static const String message = 'You are about to declare an emergency.\nWould you like to declare an actual emergency or a test?';
+  static const String buttonEmergency = 'Emergency';
+  static const String buttonTest = 'Test';
+  static const String buttonCancel = 'Cancel';
+}
+
 /// Login related strings
 class LoginStrings {
   static const String login = 'Login';

--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -2,6 +2,7 @@
 class AppStrings {
   static const String appName = 'Support Sphere';
   static const String signUpWelcome = 'Welcome to ${AppStrings.appName}\nCreate a new account and prepare with your community';
+  static const String testEmergencyBannerText = "This is a test emergency.";
 }
 
 class EmergencyAlertDialogStrings {

--- a/src/support_sphere/lib/data/models/operational_event.dart
+++ b/src/support_sphere/lib/data/models/operational_event.dart
@@ -1,6 +1,4 @@
 import 'package:equatable/equatable.dart';
-import 'package:support_sphere/constants/string_catalog.dart';
-import 'package:support_sphere/logic/bloc/app_bloc.dart';
 
 class OperationalEvent extends Equatable {
   const OperationalEvent({

--- a/src/support_sphere/lib/data/models/operational_event.dart
+++ b/src/support_sphere/lib/data/models/operational_event.dart
@@ -1,4 +1,5 @@
 import 'package:equatable/equatable.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
 import 'package:support_sphere/logic/bloc/app_bloc.dart';
 
 class OperationalEvent extends Equatable {
@@ -16,17 +17,4 @@ class OperationalEvent extends Equatable {
 
   @override
   List<Object?> get props => [id, createdBy, createdAt, operationalStatus];
-
-  AppModes get appMode {
-    switch (operationalStatus) {
-      case 'NORMAL':
-        return AppModes.normal;
-      case 'EMERGENCY':
-        return AppModes.emergency;
-      case 'TEST':
-        return AppModes.testEmergency;
-      default:
-        return AppModes.normal;
-    }
-  }
 }

--- a/src/support_sphere/lib/logic/bloc/app_bloc.dart
+++ b/src/support_sphere/lib/logic/bloc/app_bloc.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
 import 'package:support_sphere/data/models/operational_event.dart';
 import 'package:support_sphere/data/repositories/app.dart';
 
@@ -16,7 +17,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
     on<AppOnStatusChangeRequested>(_updateStatus);
 
     _operationalStatusSubscription = _appRepository.operationalStatus.listen(
-      (data) => add(AppOnModeChanged(data.appMode)),
+      (data) => add(AppOnModeChanged(data.operationalStatus)),
     );
   }
 
@@ -29,7 +30,7 @@ class AppBloc extends Bloc<AppEvent, AppState> {
   }
 
   void _updateStatus(AppOnStatusChangeRequested event, Emitter<AppState> emit) {
-    _appRepository.changeOperationalStatus(operationalStatus: event.mode.name);
+    _appRepository.changeOperationalStatus(operationalStatus: event.mode);
   }
 
   void _onBottomNavIndexChanged(

--- a/src/support_sphere/lib/logic/bloc/app_event.dart
+++ b/src/support_sphere/lib/logic/bloc/app_event.dart
@@ -8,7 +8,7 @@ class AppEvent extends Equatable {
 class AppOnModeChanged extends AppEvent {
   AppOnModeChanged(this.mode);
 
-  final AppModes mode;
+  final String mode;
 
   @override
   List<Object> get props => [mode];
@@ -17,7 +17,7 @@ class AppOnModeChanged extends AppEvent {
 class AppOnStatusChangeRequested extends AppEvent {
   AppOnStatusChangeRequested(this.mode);
 
-  final AppModes mode;
+  final String mode;
 
   @override
   List<Object> get props => [mode];

--- a/src/support_sphere/lib/logic/bloc/app_state.dart
+++ b/src/support_sphere/lib/logic/bloc/app_state.dart
@@ -1,25 +1,19 @@
 part of 'app_bloc.dart';
 
-enum AppModes {
-  normal,
-  emergency,
-  testEmergency,
-}
-
 class AppState extends Equatable {
   const AppState({
     this.mode = AppModes.normal,
     this.selectedBottomNavIndex = 0,
   });
 
-  final AppModes mode;
+  final String mode;
   final int selectedBottomNavIndex;
 
   @override
   List<Object> get props => [mode, selectedBottomNavIndex];
 
   AppState copyWith({
-    AppModes? mode,
+    String? mode,
     int? selectedBottomNavIndex,
   }) {
     return AppState(

--- a/src/support_sphere/lib/main.dart
+++ b/src/support_sphere/lib/main.dart
@@ -3,15 +3,11 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
 import 'package:support_sphere/constants/color.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:support_sphere/data/models/all_models.dart';
 import 'package:support_sphere/presentation/router/auth_select.dart';
-import 'package:support_sphere/presentation/router/flows/onboarding_flow.dart';
 import 'package:support_sphere/utils/config.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:support_sphere/logic/bloc/auth/authentication_bloc.dart';
 import 'package:support_sphere/data/repositories/authentication.dart';
-import 'package:flow_builder/flow_builder.dart';
-import 'package:support_sphere/presentation/pages/landing_page.dart';
 
 void main() async {
   try {

--- a/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
@@ -16,66 +16,90 @@ class AppPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return BlocProvider(
       create: (_) => AppBloc(appRepository: AppRepository()),
-      child: BlocBuilder<AppBloc, AppState>(
-        buildWhen: (previous, current) =>
-            previous.selectedBottomNavIndex != current.selectedBottomNavIndex,
-        builder: (context, state) {
-          return SafeArea(
-            child: Scaffold(
-              appBar: AppBar(
-                // TODO: Add hamburger menu
-                // leading: Builder(
-                //   builder: (context) {
-                //     return IconButton(
-                //       icon: const Icon(color: Colors.white, Ionicons.menu_outline),
-                //       onPressed: () {
-                //         Scaffold.of(context).openDrawer();
-                //       },
-                //     );
-                //   },
-                // ),
-                // TODO: Change color to red during emergency mode
-                backgroundColor: Theme.of(context).colorScheme.primaryContainer,
-                // TODO: Add "Emergency Declared" title during emergency mode
-                title: const Text(
-                  AppStrings.appName,
-                  style: TextStyle(color: Colors.white),
-                ),
-                actions: const [
-                  _DeclareEmergencyButton(),
-                  // TODO: Add notifications badge
-                  // IconButton(
-                  //   icon: const Badge(
-                  //       label: Text('2'),
-                  //       child: Icon(Ionicons.notifications_sharp)),
-                  //   color: Colors.white,
-                  //   onPressed: () {},
-                  // ),
-                ],
+      child: BlocListener<AppBloc, AppState>(
+        listener: (context, state) {
+          /// Show a banner if the app is in test emergency mode
+          /// This is to help users understand that the emergency
+          /// is not real and is only a test
+          if (state.mode == AppModes.testEmergency) {
+            ScaffoldMessenger.of(context).showMaterialBanner(
+              const MaterialBanner(
+                padding: EdgeInsets.all(5),
+                content: Text('This is a test emergency.'),
+                leading: Icon(Ionicons.warning_sharp),
+                backgroundColor: Colors.yellow,
+                actions: [SizedBox()],
               ),
-              // TODO: Add hamburger menu navigation
-              // drawer: const Drawer(
-              //   child: null,
-              // ),
-              body: AppBodySelect.getBody(state.selectedBottomNavIndex),
-              bottomNavigationBar: NavigationBar(
-                selectedIndex: state.selectedBottomNavIndex,
-                onDestinationSelected: (value) {
-                  context
-                      .read<AppBloc>()
-                      .add(AppOnBottomNavIndexChanged(value));
-                },
-                destinations: [
-                  for (final destination in AppBodySelect.destinations)
-                    NavigationDestination(
-                      icon: destination.icon,
-                      label: destination.label,
-                    )
-                ],
-              ),
-            ),
-          );
+            );
+          } else {
+            ScaffoldMessenger.of(context).removeCurrentMaterialBanner();
+          }
         },
+        child: BlocBuilder<AppBloc, AppState>(
+          buildWhen: (previous, current) =>
+              previous.selectedBottomNavIndex != current.selectedBottomNavIndex ||
+              previous.mode != current.mode,
+          builder: (context, state) {
+            return SafeArea(
+              child: Scaffold(
+                appBar: AppBar(
+                  // TODO: Add hamburger menu
+                  // leading: Builder(
+                  //   builder: (context) {
+                  //     return IconButton(
+                  //       icon: const Icon(color: Colors.white, Ionicons.menu_outline),
+                  //       onPressed: () {
+                  //         Scaffold.of(context).openDrawer();
+                  //       },
+                  //     );
+                  //   },
+                  // ),
+                  // TODO: Change color to red during emergency mode
+                  backgroundColor:
+                      state.mode == AppModes.normal
+                      ? Theme.of(context).colorScheme.primaryContainer
+                      : Colors.red,
+                  // TODO: Add "Emergency Declared" title during emergency mode
+                  title: const Text(
+                    AppStrings.appName,
+                    style: TextStyle(color: Colors.white),
+                  ),
+                  actions: const [
+                    _DeclareEmergencyButton(),
+                    // TODO: Add notifications badge
+                    // IconButton(
+                    //   icon: const Badge(
+                    //       label: Text('2'),
+                    //       child: Icon(Ionicons.notifications_sharp)),
+                    //   color: Colors.white,
+                    //   onPressed: () {},
+                    // ),
+                  ],
+                ),
+                // TODO: Add hamburger menu navigation
+                // drawer: const Drawer(
+                //   child: null,
+                // ),
+                body: AppBodySelect.getBody(state.selectedBottomNavIndex),
+                bottomNavigationBar: NavigationBar(
+                  selectedIndex: state.selectedBottomNavIndex,
+                  onDestinationSelected: (value) {
+                    context
+                        .read<AppBloc>()
+                        .add(AppOnBottomNavIndexChanged(value));
+                  },
+                  destinations: [
+                    for (final destination in AppBodySelect.destinations)
+                      NavigationDestination(
+                        icon: destination.icon,
+                        label: destination.label,
+                      )
+                  ],
+                ),
+              ),
+            );
+          },
+        ),
       ),
     );
   }
@@ -90,8 +114,19 @@ class _DeclareEmergencyButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
 
+    Future<void> showChangeModeAlert(BuildContext parentContext) async {
+      print(parentContext);
+      return showDialog<void>(
+        context: context,
+        barrierDismissible: false, // user must tap button!
+        builder: (BuildContext context) {
+          return _AppModeChangeDialog(parentContext: parentContext);
+        },
+      );
+    }
+  
     Widget iconButton = IconButton(
-      onPressed: () => print("Emergency button pressed"),
+      onPressed: () => showChangeModeAlert(context),
       icon: Icon(Ionicons.radio_outline),
       color: Colors.white,
     );
@@ -108,5 +143,130 @@ class _DeclareEmergencyButton extends StatelessWidget {
           return SizedBox();
       }
     });
+  }
+}
+
+class _AppModeChangeDialog extends StatelessWidget {
+  const _AppModeChangeDialog({super.key, required this.parentContext});
+
+  final BuildContext parentContext;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider.value(
+      value: parentContext.read<AppBloc>(),
+      child: BlocBuilder<AppBloc, AppState>(
+        builder: (context, state) {
+          // Show different alert dialog based on the current mode
+          switch (state.mode) {
+            case AppModes.normal:
+              return _NormalAlertDialog(parentContext: parentContext);
+            case AppModes.emergency:
+              return _EmergencyAlertDialog(parentContext: parentContext);
+            case AppModes.testEmergency:
+              return _EmergencyAlertDialog(parentContext: parentContext);
+            default:
+              return const SizedBox();
+          }
+        },
+      ),
+    );
+  }
+}
+
+/// Emergency mode alert dialog
+/// This dialog will ask the user if they want to return to normal mode.
+///
+/// If the user selects "Yes", the app will switch to normal mode.
+/// If the user selects "No", the dialog will close.
+class _EmergencyAlertDialog extends StatelessWidget {
+  const _EmergencyAlertDialog({super.key, required this.parentContext});
+
+  final BuildContext parentContext;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('Emergency Declared'),
+      content: const SingleChildScrollView(
+        child: ListBody(
+          children: <Widget>[
+            Text('An emergency has been declared.'),
+            Text('Would you like to return to normal mode?'),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Yes'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            parentContext
+                .read<AppBloc>()
+                .add(AppOnStatusChangeRequested(AppModes.normal));
+          },
+        ),
+        TextButton(
+          child: const Text('No'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+      ],
+    );
+  }
+}
+
+/// Normal mode alert dialog
+/// This dialog will ask the user if they want to declare an emergency
+/// or a test emergency.
+///
+/// If the user selects "Emergency", the app will switch to emergency mode.
+/// If the user selects "Test", the app will switch to test emergency mode.
+/// If the user selects "Cancel", the dialog will close.
+class _NormalAlertDialog extends StatelessWidget {
+  const _NormalAlertDialog({super.key, required this.parentContext});
+
+  final BuildContext parentContext;
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text('Declare An Emergency'),
+      content: const SingleChildScrollView(
+        child: ListBody(
+          children: <Widget>[
+            Text('You are about to declare an emergency.'),
+            Text('Would you like to declare an actual emergency or a test?'),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          child: const Text('Cancel'),
+          onPressed: () {
+            Navigator.of(context).pop();
+          },
+        ),
+        TextButton(
+          child: const Text('Test'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            parentContext
+                .read<AppBloc>()
+                .add(AppOnStatusChangeRequested(AppModes.testEmergency));
+          },
+        ),
+        TextButton(
+          child: const Text('Emergency'),
+          onPressed: () {
+            Navigator.of(context).pop();
+            parentContext
+                .read<AppBloc>()
+                .add(AppOnStatusChangeRequested(AppModes.emergency));
+          },
+        ),
+      ],
+    );
   }
 }

--- a/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
@@ -37,7 +37,8 @@ class AppPage extends StatelessWidget {
         },
         child: BlocBuilder<AppBloc, AppState>(
           buildWhen: (previous, current) =>
-              previous.selectedBottomNavIndex != current.selectedBottomNavIndex ||
+              previous.selectedBottomNavIndex !=
+                  current.selectedBottomNavIndex ||
               previous.mode != current.mode,
           builder: (context, state) {
             return SafeArea(
@@ -55,8 +56,7 @@ class AppPage extends StatelessWidget {
                   //   },
                   // ),
                   // TODO: Change color to red during emergency mode
-                  backgroundColor:
-                      state.mode == AppModes.normal
+                  backgroundColor: state.mode == AppModes.normal
                       ? Theme.of(context).colorScheme.primaryContainer
                       : Colors.red,
                   // TODO: Add "Emergency Declared" title during emergency mode
@@ -113,7 +113,6 @@ class _DeclareEmergencyButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     Future<void> showChangeModeAlert(BuildContext parentContext) async {
       print(parentContext);
       return showDialog<void>(
@@ -124,7 +123,7 @@ class _DeclareEmergencyButton extends StatelessWidget {
         },
       );
     }
-  
+
     Widget iconButton = IconButton(
       onPressed: () => showChangeModeAlert(context),
       icon: Icon(Ionicons.radio_outline),
@@ -187,18 +186,17 @@ class _EmergencyAlertDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text('Emergency Declared'),
+      title: const Text(EmergencyAlertDialogStrings.title),
       content: const SingleChildScrollView(
         child: ListBody(
           children: <Widget>[
-            Text('An emergency has been declared.'),
-            Text('Would you like to return to normal mode?'),
+            Text(EmergencyAlertDialogStrings.message),
           ],
         ),
       ),
       actions: <Widget>[
         TextButton(
-          child: const Text('Yes'),
+          child: const Text(EmergencyAlertDialogStrings.buttonYes),
           onPressed: () {
             Navigator.of(context).pop();
             parentContext
@@ -207,7 +205,7 @@ class _EmergencyAlertDialog extends StatelessWidget {
           },
         ),
         TextButton(
-          child: const Text('No'),
+          child: const Text(EmergencyAlertDialogStrings.buttonNo),
           onPressed: () {
             Navigator.of(context).pop();
           },
@@ -232,24 +230,25 @@ class _NormalAlertDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
-      title: Text('Declare An Emergency'),
+      title: const Text(NormalAlertDialogStrings.title),
       content: const SingleChildScrollView(
         child: ListBody(
           children: <Widget>[
-            Text('You are about to declare an emergency.'),
-            Text('Would you like to declare an actual emergency or a test?'),
+            Text(NormalAlertDialogStrings.message),
           ],
         ),
       ),
       actions: <Widget>[
+        // Cancel button
         TextButton(
-          child: const Text('Cancel'),
+          child: const Text(NormalAlertDialogStrings.buttonCancel),
           onPressed: () {
             Navigator.of(context).pop();
           },
         ),
+        // Test button
         TextButton(
-          child: const Text('Test'),
+          child: const Text(NormalAlertDialogStrings.buttonTest),
           onPressed: () {
             Navigator.of(context).pop();
             parentContext
@@ -257,8 +256,9 @@ class _NormalAlertDialog extends StatelessWidget {
                 .add(AppOnStatusChangeRequested(AppModes.testEmergency));
           },
         ),
+        // Emergency button
         TextButton(
-          child: const Text('Emergency'),
+          child: const Text(NormalAlertDialogStrings.buttonEmergency),
           onPressed: () {
             Navigator.of(context).pop();
             parentContext

--- a/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
@@ -25,7 +25,7 @@ class AppPage extends StatelessWidget {
             ScaffoldMessenger.of(context).showMaterialBanner(
               const MaterialBanner(
                 padding: EdgeInsets.all(5),
-                content: Text('This is a test emergency.'),
+                content: Text(AppStrings.testEmergencyBannerText),
                 leading: Icon(Ionicons.warning_sharp),
                 backgroundColor: Colors.yellow,
                 actions: [SizedBox()],


### PR DESCRIPTION
This PR integrates the emergency to the backend. This is part of #27. This allows user to declare emergency. 

## Demo

### Normal mode

<img width="1496" alt="Screenshot 2024-09-25 at 3 19 59 PM" src="https://github.com/user-attachments/assets/e3dd9213-6ca1-4591-adc9-a4b7485d2dcc">

### Test Emergency Mode

<img width="1496" alt="Screenshot 2024-09-25 at 3 20 15 PM" src="https://github.com/user-attachments/assets/4b1746d3-5713-4f07-854a-ec9dad9a0b06">

Notice that in the back the yellow banner says that it's a test emergency. This is for the user to know it's not an actual one.

### Emergency Mode
<img width="1496" alt="Screenshot 2024-09-25 at 3 20 37 PM" src="https://github.com/user-attachments/assets/9c7df083-9934-499c-bb3e-2810be2a0d0f">

The dialog is duplicate to the test one
