### PR TITLE
feat: Add profile page skeleton, user, and household sections

### DIFF
--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:ionicons/ionicons.dart';
+import 'package:support_sphere/presentation/pages/main_app/profile/profile_body.dart';
 
 class AppRoute extends Equatable {
   const AppRoute({required this.icon, required this.label, this.body});
@@ -19,7 +20,7 @@ class AppNavigation {
     const AppRoute(
         icon: Icon(Ionicons.home_sharp), label: 'Home'),
     const AppRoute(
-        icon: Icon(Ionicons.person_sharp), label: 'Me'),
+        icon: Icon(Ionicons.person_sharp), label: 'Me', body: ProfileBody()),
     const AppRoute(
         icon: Icon(Ionicons.shield_checkmark_sharp), label: 'Prepare'),
     const AppRoute(icon: Icon(Ionicons.hammer_sharp), label: 'Resources'),

--- a/src/support_sphere/lib/data/models/households.dart
+++ b/src/support_sphere/lib/data/models/households.dart
@@ -1,0 +1,58 @@
+import 'package:equatable/equatable.dart';
+import 'package:support_sphere/data/models/person.dart';
+
+class Household extends Equatable {
+
+  const Household({
+    required this.id,
+    this.name = '',
+    this.address = '',
+    this.notes = '',
+    this.pets = '',
+    this.accessibility_needs = '',
+    this.houseHoldMembers = null,
+  });
+
+  /// The current user's id, which matches the auth user id
+  final String id;
+  final String? name;
+  final String? address;
+  final String? notes;
+  final String? pets;
+  final String? accessibility_needs;
+  final HouseHoldMembers? houseHoldMembers;
+
+  @override
+  List<Object?> get props => [id, name, address, notes, pets, accessibility_needs, houseHoldMembers];
+
+  copyWith({
+    String? id,
+    String? name,
+    String? address,
+    String? notes,
+    String? pets,
+    String? accessibility_needs,
+    HouseHoldMembers? houseHoldMembers,
+  }) {
+    return Household(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      address: address ?? this.address,
+      notes: notes ?? this.notes,
+      pets: pets ?? this.pets,
+      accessibility_needs: accessibility_needs ?? this.accessibility_needs,
+      houseHoldMembers: houseHoldMembers ?? this.houseHoldMembers,
+    );
+  }
+}
+
+class HouseHoldMembers extends Equatable {
+  const HouseHoldMembers({
+    this.members = const [],
+  });
+
+  final List<Person?> members;
+
+  @override
+  List<Object?> get props => [members];
+}

--- a/src/support_sphere/lib/data/repositories/authentication.dart
+++ b/src/support_sphere/lib/data/repositories/authentication.dart
@@ -30,7 +30,8 @@ class AuthenticationRepository {
   Future<void> logIn({
     required String email,
     required String password,
-  }) async => _authService.signInWithEmailAndPassword(email, password);
+  }) async =>
+      _authService.signInWithEmailAndPassword(email, password);
 
   Future<void> logOut() async => await _authService.signOut();
 
@@ -48,7 +49,13 @@ class AuthenticationRepository {
   }
 
   AuthUser _parseUser(supabase_flutter.User? user, String userRole) {
-    return user == null ? AuthUser.empty : AuthUser(uuid: user.id, userRole: userRole);
+    return user == null
+        ? AuthUser.empty
+        : AuthUser(
+            uuid: user.id,
+            userRole: userRole,
+            email: user.email,
+            phone: user.phone);
   }
 
   String _parseUserRole(supabase_flutter.Session? session) {

--- a/src/support_sphere/lib/data/repositories/user.dart
+++ b/src/support_sphere/lib/data/repositories/user.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:supabase_flutter/supabase_flutter.dart' as supabase_flutter;
 import 'package:support_sphere/data/models/auth_user.dart';
+import 'package:support_sphere/data/models/households.dart';
 import 'package:support_sphere/data/models/person.dart';
 import 'package:support_sphere/data/services/user_service.dart';
 
@@ -9,6 +10,60 @@ import 'package:support_sphere/data/services/user_service.dart';
 /// This class is responsible for handling user-related data operations.
 class UserRepository {
   final UserService _userService = UserService();
+
+  /// Get the household members by household id.
+  /// Returns a [HouseHoldMembers] object if the household members exist.
+  /// Returns null if the household members do not exist.
+  /// The [HouseHoldMembers] object contains a list of [Person] objects.
+  Future<HouseHoldMembers?> getHouseholdMembersByHouseholdId(
+      String householdId) async {
+    final data = await _userService.getHouseholdMembersByHouseholdId(householdId);
+
+    if (data != null) {
+      List<Person> members = [];
+      for (var member in data) {
+        Map<String, dynamic> personData = member["people"];
+        Profile? profile;
+        String? userProfileId = personData["user_profile_id"];
+
+        if (userProfileId != null) {
+          profile = Profile(id: userProfileId);
+        }
+
+        members.add(Person(
+          id: personData["id"],
+          profile: profile,
+          givenName: personData["given_name"],
+          familyName: personData["family_name"],
+          nickname: personData["nickname"],
+          isSafe: personData["is_safe"],
+          needsHelp: personData["needs_help"],
+        ));
+      }
+
+      return HouseHoldMembers(members: members);
+    }
+    return null;
+  }
+
+  /// Get the household by person id.
+  Future<Household?> getHouseholdByPersonId(String personId) async {
+    final data = await _userService.getPersonHouseholdByPersonId(personId);
+
+    if (data != null) {
+      Map<String, dynamic> householdData = data["households"];
+
+      return Household(
+        id: householdData["id"],
+        name: householdData["name"],
+        address: householdData["address"],
+        notes: householdData["notes"],
+        pets: householdData["pets"],
+        accessibility_needs: householdData["accessibility_needs"],
+      );
+    }
+    return null;
+  }
 
   /// Get the user profile and person by user id retrieved from [AuthUser].
   /// Returns a [Person] object if the user profile and person exist.

--- a/src/support_sphere/lib/data/services/user_service.dart
+++ b/src/support_sphere/lib/data/services/user_service.dart
@@ -5,6 +5,38 @@ import 'package:uuid/v4.dart';
 class UserService {
   final SupabaseClient _supabaseClient = supabase;
 
+  /// Retrieves the person household by person id.
+  Future<PostgrestMap?> getPersonHouseholdByPersonId(String personId) async {
+    return await _supabaseClient.from('people_groups').select('''
+      people(
+        id
+      ),
+      households(
+        id,
+        name,
+        address,
+        notes,
+        pets,
+        accessibility_needs
+      )
+    ''').eq('people_id', personId).maybeSingle();
+  }
+
+  /// Retrieves the household members by household id.
+  Future<PostgrestList?> getHouseholdMembersByHouseholdId(String householdId) async {
+    return await _supabaseClient.from('people_groups').select('''
+      people(
+        id,
+        user_profile_id,
+        given_name,
+        family_name,
+        nickname,
+        is_safe,
+        needs_help
+      )
+    ''').eq('household_id', householdId);
+  }
+
   /// Retrieves the user profile and person by user id.
   /// Returns a [PostgrestMap] object if the user profile and person exist.
   /// Returns null if the user profile and person do not exist.
@@ -12,7 +44,6 @@ class UserService {
     /// This query will perform a join on the user_profiles and people tables
     return await _supabaseClient.from('user_profiles').select('''
       id,
-      username,
       people(
         id,
         user_profile_id,
@@ -31,9 +62,6 @@ class UserService {
   }) async {
     await _supabaseClient.from('user_profiles').insert({
       'id': userId,
-      // The username is empty by default
-      // this is because it can't be null in the database
-      'username': '',
     });
   }
 

--- a/src/support_sphere/lib/logic/cubit/profile_cubit.dart
+++ b/src/support_sphere/lib/logic/cubit/profile_cubit.dart
@@ -1,0 +1,62 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:support_sphere/data/models/auth_user.dart';
+import 'package:support_sphere/data/models/households.dart';
+import 'package:support_sphere/data/models/person.dart';
+import 'package:support_sphere/data/repositories/user.dart';
+
+part 'profile_state.dart';
+
+class ProfileCubit extends Cubit<ProfileState> {
+  ProfileCubit(this.authUser) : super(const ProfileState()) {
+    authUserChanged(authUser);
+    fetchProfile();
+  }
+
+  final AuthUser authUser;
+  final UserRepository _userRepository = UserRepository();
+
+  void profileChanged(Person? userProfile) {
+    emit(state.copyWith(userProfile: userProfile));
+  }
+
+  void authUserChanged(AuthUser? authUser) {
+    emit(state.copyWith(authUser: authUser));
+  }
+
+  void householdChanged(Household? household) {
+    emit(state.copyWith(household: household));
+  }
+
+  Future<void> fetchProfile() async {
+    try {
+      /// Get the user profile by user id
+      final Person? userProfile = await _userRepository.getPersonProfileByUserId(
+        userId: authUser.uuid,
+      );
+      profileChanged(userProfile);
+      if (userProfile == null) {
+        throw Exception('User profile not found');
+      }
+
+      /// Get the household of the user profile
+      Household? household = await _userRepository.getHouseholdByPersonId(
+        userProfile.id,
+      );
+      if (household != null) {
+        /// Get the household members of the household
+        final HouseHoldMembers? houseHoldMembers = await _userRepository.getHouseholdMembersByHouseholdId(household.id);
+
+        if (houseHoldMembers != null) {
+          household = household.copyWith(houseHoldMembers: houseHoldMembers);
+        }
+        householdChanged(household);
+      } else {
+        throw Exception('Household not found');
+      }
+    } catch (_) {
+      /// TODO: Handle error if there are no user profile or household for some reason
+      profileChanged(null);
+    }
+  }
+}

--- a/src/support_sphere/lib/logic/cubit/profile_state.dart
+++ b/src/support_sphere/lib/logic/cubit/profile_state.dart
@@ -1,0 +1,28 @@
+part of 'profile_cubit.dart';
+
+class ProfileState extends Equatable {
+  const ProfileState({
+    this.userProfile,
+    this.household,
+    this.authUser,
+  });
+
+  final Person? userProfile;
+  final AuthUser? authUser;
+  final Household? household;
+
+  @override
+  List<Object?> get props => [userProfile, authUser, household];
+
+  ProfileState copyWith({
+    Person? userProfile,
+    AuthUser? authUser,
+    Household? household,
+  }) {
+    return ProfileState(
+      userProfile: userProfile ?? this.userProfile,
+      authUser: authUser ?? this.authUser,
+      household: household ?? this.household,
+    );
+  }
+}

--- a/src/support_sphere/lib/presentation/pages/main_app/profile/profile_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/profile/profile_body.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import 'package:ionicons/ionicons.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:support_sphere/data/models/auth_user.dart';
+import 'package:support_sphere/data/models/households.dart';
+import 'package:support_sphere/data/models/person.dart';
+import 'package:support_sphere/logic/bloc/auth/authentication_bloc.dart';
+import 'package:support_sphere/logic/cubit/profile_cubit.dart';
+
+/// Profile Body Widget
+class ProfileBody extends StatelessWidget {
+  const ProfileBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final AuthUser authUser = context.select(
+      (AuthenticationBloc bloc) => bloc.state.user,
+    );
+
+    return BlocProvider(
+      create: (context) => ProfileCubit(authUser),
+      child: LayoutBuilder(builder: (context, constraint) {
+        return Column(
+          children: [
+            Container(
+              height: 50,
+              child: const Center(
+                // TODO: Add profile picture
+                child: Text('User Profile',
+                    style:
+                        TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+              ),
+            ),
+            Expanded(
+              child: Container(
+                height: MediaQuery.sizeOf(context).height,
+                padding: const EdgeInsets.all(10),
+                child: ListView(
+                  shrinkWrap: true,
+                  scrollDirection: Axis.vertical,
+                  children: const [
+                    // Personal Information
+                    _PersonalInformation(),
+                    // Household Information
+                    _HouseholdInformation(),
+                    // Cluster Information
+                    _ClusterInformation(),
+                    // TODO: Add Privacy and Notifications
+                    // Privacy and Notifications
+                    // _PrivacyAndNotifications(),
+                    // Log Out Button
+                    _LogOutButton(),
+                  ],
+                ),
+              ),
+            )
+          ],
+        );
+      }),
+    );
+  }
+}
+
+class _LogOutButton extends StatelessWidget {
+  const _LogOutButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AuthenticationBloc, AuthenticationState>(
+      builder: (context, state) {
+        return Padding(
+          padding: const EdgeInsets.all(10),
+          child: ElevatedButton.icon(
+            onPressed: () =>
+                context.read<AuthenticationBloc>().add(AuthOnLogoutRequested()),
+            icon: const Icon(Ionicons.log_out_outline),
+            label: const Text('Log Out'),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _ProfileSection extends StatelessWidget {
+  const _ProfileSection(
+      {super.key,
+      this.title = "Section Header",
+      this.children = const [],
+      this.displayTitle = true,
+      this.readOnly = false});
+
+  final String title;
+  final List<Widget> children;
+  final bool displayTitle;
+  final bool readOnly;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(10),
+      child: Column(
+        children: [
+          _getTitle(context) ?? const SizedBox(),
+          Card(
+            child: Padding(
+              padding: const EdgeInsets.all(8.0),
+              child: Column(
+                children: children,
+              ),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  Future<dynamic> _showModalBottomSheet(BuildContext context) {
+    return showCupertinoModalBottomSheet(
+        expand: true,
+        context: context,
+
+        /// TODO: Implement Edit modal
+        builder: (context) => Container());
+  }
+
+  /// Get the title of the section
+  /// If the title is not displayed, return null
+  /// If the title is displayed, return a ListTile with the title and an edit icon
+  /// If the section is read only, don't show the edit icon
+  /// If the section is not read only, show the edit icon
+  Widget? _getTitle(BuildContext context) {
+    if (displayTitle) {
+      // return Center(child: Text(title));
+      return ListTile(
+        title: Text(title),
+        trailing: readOnly
+            ? null
+            : GestureDetector(
+                onTap: () => _showModalBottomSheet(context),
+                child: const Icon(Ionicons.create_outline),
+              ),
+      );
+    }
+    return null;
+  }
+}
+
+class _PersonalInformation extends StatelessWidget {
+  const _PersonalInformation({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      buildWhen: (previous, current) =>
+          previous.userProfile != current.userProfile,
+      builder: (context, state) {
+        Person? userProfile = state.userProfile;
+        AuthUser? authUser = state.authUser;
+        String givenName = userProfile?.givenName ?? '';
+        String familyName = userProfile?.familyName ?? '';
+        String fullName = '$givenName $familyName';
+        String phoneNumber = authUser?.phone ?? '';
+        String email = authUser?.email ?? '';
+        return _ProfileSection(
+          title: "Personal Information",
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Name"),
+                Text(fullName),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Phone"),
+                Text(phoneNumber),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Email"),
+                Text(email),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _HouseholdInformation extends StatelessWidget {
+  const _HouseholdInformation({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ProfileCubit, ProfileState>(
+      buildWhen: (previous, current) => previous.household != current.household,
+      builder: (context, state) {
+        Household? household = state.household;
+        String address = household?.address ?? '';
+        String pets = household?.pets ?? '';
+        String notes = household?.notes ?? '';
+        String accessibilityNeeds = household?.accessibility_needs ?? 'None';
+        List<Person?> householdMembers =
+            household?.houseHoldMembers?.members ?? [];
+        List<String> members = householdMembers.map((person) {
+          String givenName = person?.givenName ?? '';
+          String familyName = person?.familyName ?? '';
+          String fullName = '$givenName $familyName';
+          return fullName;
+        }).toList();
+        return _ProfileSection(
+          title: "Household Information",
+          children: [
+            const Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Household Members"),
+              ],
+            ),
+            Container(
+              height: 50.0,
+              child: ListView(shrinkWrap: true, children: [
+                for (var member in members)
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(member),
+                    ],
+                  ),
+              ]),
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Address"),
+                Text(address),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Pets"),
+                Text(pets),
+              ],
+            ),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Accessiblity Needs"),
+                Text(accessibilityNeeds),
+              ],
+            ),
+            const Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text("Notes (visible to cluster captain(s))"),
+              ],
+            ),
+            Container(
+              height: 50,
+              child: TextField(
+                controller: TextEditingController()..text = notes,
+                expands: true,
+                maxLines: null,
+                readOnly: true,
+                decoration:
+                    InputDecoration(filled: true, fillColor: Colors.grey[200]),
+              ),
+            )
+          ],
+        );
+      },
+    );
+  }
+}
+
+/// Cluster Information
+class _ClusterInformation extends StatelessWidget {
+  /// TODO: Add cluster information from database
+  const _ClusterInformation({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Cluster Information
+    return _ProfileSection(
+      title: "Cluster Information",
+      readOnly: true,
+      children: [
+        const Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text("Name"),
+            Text("Cluster 1"),
+          ],
+        ),
+        const Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text("Meeting place"),
+            Text("410 Example Street"),
+          ],
+        ),
+        const Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text("Captain(s)"),
+          ],
+        ),
+        Container(
+          height: 50.0,
+          child: ListView(shrinkWrap: true, children: const [
+            Text("Jane Smith"),
+            Text("John Smith"),
+          ]),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Overview

This PR partially satisfy #120. It contains the following changes:

- [X] Set up the profile body page skeleton #121 
- [X] Setup the logic to retrieve the user info and household info
- [X] Adds the personal info section, #122 
- [X] Adds the household info section #123 

## Demo
<img width="331" alt="Screenshot 2024-10-16 at 12 09 42 PM" src="https://github.com/user-attachments/assets/d3f85474-fb80-4d59-8d71-67825d3bf414">

