### PR TITLE
ci: Update CI to only run on changes to the python code

### DIFF
--- a/.github/workflows/cd_support_sphere_py.yml
+++ b/.github/workflows/cd_support_sphere_py.yml
@@ -3,6 +3,8 @@ name: Publish Support Sphere Python Package to PyPI and TestPyPI
 on:
   workflow_dispatch:
   push:
+    paths:
+      - 'src/support_sphere_py/**'
     branches:
       - main
   release:


### PR DESCRIPTION
This PR update the fact that the CI runs for all code changes, but rather make it only for changes to python code.