### PR TITLE
refactor: Make hardcoded string for routes and app roles to constants

### DIFF
--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -1,6 +1,7 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:ionicons/ionicons.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
 import 'package:support_sphere/presentation/pages/main_app/profile/profile_body.dart';
 
 class AppRoute extends Equatable {
@@ -19,20 +20,20 @@ class AppNavigation {
     // TODO: Add body for each route
     List<AppRoute> destinations = [
       const AppRoute(
-          icon: Icon(Ionicons.home_sharp), label: 'Home'),
+          icon: Icon(Ionicons.home_sharp), label: NavRouteLabels.home),
       const AppRoute(
-          icon: Icon(Ionicons.person_sharp), label: 'Me', body: ProfileBody()),
+          icon: Icon(Ionicons.person_sharp), label: NavRouteLabels.profile, body: ProfileBody()),
       const AppRoute(
-          icon: Icon(Ionicons.shield_checkmark_sharp), label: 'Prepare'),
-      const AppRoute(icon: Icon(Ionicons.hammer_sharp), label: 'Resources'),
+          icon: Icon(Ionicons.shield_checkmark_sharp), label: NavRouteLabels.prepare),
+      const AppRoute(icon: Icon(Ionicons.hammer_sharp), label: NavRouteLabels.resources),
     ];
-    if (role == "COM_ADMIN") {
+    if (role == AppRoles.communityAdmin) {
       // TODO: Make this display only for certain screen size
       destinations = destinations + [
         const AppRoute(
-            icon: Icon(Ionicons.construct_sharp), label: 'Manage Resources'),
+            icon: Icon(Ionicons.construct_sharp), label: NavRouteLabels.manageResources),
         const AppRoute(
-            icon: Icon(Ionicons.list_sharp), label: 'Manage Checklists'),
+            icon: Icon(Ionicons.list_sharp), label: NavRouteLabels.manageChecklists),
       ];
     }
     return destinations;

--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -53,4 +53,20 @@ class AppModes {
   static const String testEmergency = 'TEST';
 }
 
+class AppRoles {
+  static const String user = 'USER';
+  static const String subcommunityAgent = 'SUBCOM_AGENT';
+  static const String communityAdmin = 'COM_ADMIN';
+  static const String admin = 'ADMIN';
+}
+
+class NavRouteLabels {
+  static const String home = 'Home';
+  static const String profile = 'Me';
+  static const String prepare = 'Prepare';
+  static const String resources = 'Resources';
+  static const String manageResources = 'Manage Resources';
+  static const String manageChecklists = 'Manage Checklists';
+}
+
 

--- a/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
@@ -159,9 +159,9 @@ class _DeclareEmergencyButton extends StatelessWidget {
       }
       switch (state.user.userRole) {
         // TODO: Change key to enums
-        case 'ADMIN':
+        case AppRoles.admin:
           return iconButton;
-        case 'COM_ADMIN':
+        case AppRoles.communityAdmin:
           return iconButton;
         default:
           return SizedBox();


### PR DESCRIPTION
This pull request includes several changes to improve code readability and maintainability by introducing constants for role and navigation route labels. The changes primarily focus on replacing hardcoded strings with defined constants and updating the related import statements.

### Constants Introduction and Usage:

* [`src/support_sphere/lib/constants/string_catalog.dart`](diffhunk://#diff-9663c9e5e9c15a602ae60e64b7178cbfd727abbac179b5aaefcab70a956373fdR56-R71): Added `AppRoles` and `NavRouteLabels` classes to define constants for user roles and navigation route labels.

### Code Refactoring:

* [`src/support_sphere/lib/constants/routes.dart`](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39L22-R36): Updated the `AppRoute` class to use `NavRouteLabels` constants instead of hardcoded strings for route labels.
* [`src/support_sphere/lib/constants/routes.dart`](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39R4): Added import statement for `string_catalog.dart` to use the newly defined constants.
* [`src/support_sphere/lib/presentation/pages/main_app/app_page.dart`](diffhunk://#diff-4ec56a88127dcbb85de402b2cce9c6a17bf89ac1aec17aeac1426813b555e8bcL162-R164): Replaced hardcoded role strings with `AppRoles` constants in the `_DeclareEmergencyButton` class.

### Related Issue

Resolves #147