### PR TITLE
feat: Add manage resources view

### DIFF
--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/presentation/pages/main_app/manage_resources/manage_resources_body.dart';
 import 'package:support_sphere/presentation/pages/main_app/profile/profile_body.dart';
 
 class AppRoute extends Equatable {
@@ -31,7 +32,7 @@ class AppNavigation {
       // TODO: Make this display only for certain screen size
       destinations = destinations + [
         const AppRoute(
-            icon: Icon(Ionicons.construct_sharp), label: NavRouteLabels.manageResources),
+            icon: Icon(Ionicons.construct_sharp), label: NavRouteLabels.manageResources, body: ManageResourcesBody()),
         const AppRoute(
             icon: Icon(Ionicons.list_sharp), label: NavRouteLabels.manageChecklists),
       ];

--- a/src/support_sphere/lib/presentation/pages/main_app/manage_resources/manage_resources_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/manage_resources/manage_resources_body.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:ionicons/ionicons.dart';
+import 'package:modal_bottom_sheet/modal_bottom_sheet.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:support_sphere/presentation/pages/main_app/manage_resources/new_resource_skill.dart';
+
+class ManageResourcesBody extends StatelessWidget {
+  const ManageResourcesBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(builder: (context, constraint) {
+      return Column(
+        children: [
+          Container(
+            height: 50,
+            child: const Center(
+              // TODO: Add profile picture
+              child: Text('Manage Resources',
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold)),
+            ),
+          ),
+          Expanded(
+            child: Container(
+                height: MediaQuery.sizeOf(context).height,
+                padding: const EdgeInsets.all(10),
+                child: Column(
+                  children: [
+                    _ButtonFiltersSection(),
+                    _TableViewSection()
+                  ],
+                )),
+          )
+        ],
+      );
+    });
+  }
+}
+
+class _ButtonFiltersSection extends StatelessWidget {
+  const _ButtonFiltersSection({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Column(
+          children: [
+            // TODO: Add new resource button
+            // const AddNewResourceSkillButton()
+          ],
+        ),
+      ],
+    );
+  }
+}
+
+
+class _TableViewSection extends StatelessWidget {
+  const _TableViewSection({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: const Center(child: Text("Table of Resources coming soon!")),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces a new `ManageResourcesBody` widget and integrates it into the navigation system. The most important changes include adding the new widget, updating the routes, and modifying the navigation to include the new widget.

### New Widget Addition:

* [`src/support_sphere/lib/presentation/pages/main_app/manage_resources/manage_resources_body.dart`](diffhunk://#diff-e55db62fcf8e1a75b1fd1e25bc77e875f6c2f6b30135c1d361dd001af82c3102R1-R68): Added a new `ManageResourcesBody` widget, which includes a layout with a placeholder for a table of resources and a section for button filters.

### Route and Navigation Updates:

* [`src/support_sphere/lib/constants/routes.dart`](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39R5): Imported the `ManageResourcesBody` widget and updated the `AppRoute` to include this new widget as the body for the `manageResources` route. [[1]](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39R5) [[2]](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39L34-R35)

## Related Issues

Resolves #162 