### PR TITLE
feat: Add basic user checklist main page

### DIFF
--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -25,7 +25,7 @@ class AppNavigation {
       const AppRoute(
           icon: Icon(Ionicons.person_sharp), label: NavRouteLabels.profile, body: ProfileBody()),
       const AppRoute(
-          icon: Icon(Ionicons.shield_checkmark_sharp), label: NavRouteLabels.prepare),
+          icon: Icon(Ionicons.shield_checkmark_sharp), label: NavRouteLabels.prepare, body: ChecklistBody()),
       const AppRoute(icon: Icon(Ionicons.hammer_sharp), label: NavRouteLabels.resources),
     ];
     if (role == AppRoles.communityAdmin) {
@@ -34,7 +34,7 @@ class AppNavigation {
         const AppRoute(
             icon: Icon(Ionicons.construct_sharp), label: NavRouteLabels.manageResources),
         const AppRoute(
-            icon: Icon(Ionicons.list_sharp), label: NavRouteLabels.manageChecklists, body: ChecklistBody()),
+            icon: Icon(Ionicons.list_sharp), label: NavRouteLabels.manageChecklists),
       ];
     }
     return destinations;

--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
 import 'package:support_sphere/presentation/pages/main_app/profile/profile_body.dart';
+import 'package:support_sphere/presentation/pages/main_app/checklist/checklist_main_body.dart';
 
 class AppRoute extends Equatable {
   const AppRoute({required this.icon, required this.label, this.body});
@@ -33,7 +34,7 @@ class AppNavigation {
         const AppRoute(
             icon: Icon(Ionicons.construct_sharp), label: NavRouteLabels.manageResources),
         const AppRoute(
-            icon: Icon(Ionicons.list_sharp), label: NavRouteLabels.manageChecklists),
+            icon: Icon(Ionicons.list_sharp), label: NavRouteLabels.manageChecklists, body: ChecklistBody()),
       ];
     }
     return destinations;

--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -1,20 +1,23 @@
 /// Strings used in the app
 class AppStrings {
   static const String appName = 'Support Sphere';
-  static const String signUpWelcome = 'Welcome to ${AppStrings.appName}\nCreate a new account and prepare with your community';
+  static const String signUpWelcome =
+      'Welcome to ${AppStrings.appName}\nCreate a new account and prepare with your community';
   static const String testEmergencyBannerText = "This is a test emergency.";
 }
 
 class EmergencyAlertDialogStrings {
   static const String title = 'Emergency Declared';
-  static const String message = 'An emergency has been declared.\nWould you like to return to normal mode?';
+  static const String message =
+      'An emergency has been declared.\nWould you like to return to normal mode?';
   static const String buttonYes = 'Yes';
   static const String buttonNo = 'No';
 }
 
 class NormalAlertDialogStrings {
   static const String title = 'Declare An Emergency';
-  static const String message = 'You are about to declare an emergency.\nWould you like to declare an actual emergency or a test?';
+  static const String message =
+      'You are about to declare an emergency.\nWould you like to declare an actual emergency or a test?';
   static const String buttonEmergency = 'Emergency';
   static const String buttonTest = 'Test';
   static const String buttonCancel = 'Cancel';
@@ -62,14 +65,30 @@ class UserProfileStrings {
   static const String submit = 'Submit';
 }
 
+/// Checklist messages
+class ChecklistStrings {
+  static const String toBeDone = 'To be Done';
+  static const String completed = 'Completed';
+  static const String noCompletedChecklist = 'No completed checklists yet';
+  static const String inProgress = 'In Progress';
+  static String stepsCount(int count) => '$count Steps';
+  static String completedOnDate(String dateStr) => 'Completed on $dateStr';
+  static const String allDone = 'All Done! 🎉';
+  static String congratulations(String dateStr) =>
+      "Congratulations, you\'ve completed all available Preparedness Checklists! Your next checklist is not due until $dateStr.";
+  static const String checkCompletedTab = 'Check the Completed tab to review your completed checklists.';
+}
+
 /// Error messages
 class ErrorMessageStrings {
   static const String invalidEmail = 'Invalid email';
   static const String invalidPassword = 'Invalid password';
   static const String invalidConfirmPassword = 'Passwords do not match';
   static const String invalidSignUpCode = 'Invalid sign up code';
-  static const String mustNotContainSpecialCharacters = 'Must not contain any special characters';
-  static const String noUserIsSignedIn = 'No user is currently signed in, please try re-login';
+  static const String mustNotContainSpecialCharacters =
+      'Must not contain any special characters';
+  static const String noUserIsSignedIn =
+      'No user is currently signed in, please try re-login';
 }
 
 /// App Modes Strings

--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -74,8 +74,9 @@ class ChecklistStrings {
   static String stepsCount(int count) => '$count Steps';
   static String completedOnDate(String dateStr) => 'Completed on $dateStr';
   static const String allDone = 'All Done! 🎉';
-  static String congratulations(String dateStr) =>
-      "Congratulations, you\'ve completed all available Preparedness Checklists! Your next checklist is not due until $dateStr.";
+  static const String congratulations = 'Congratulations, you\'ve completed all available Preparedness Checklists!';
+  static String nextChecklistDue(String dateStr) =>
+      " Your next checklist is not due until $dateStr.";
   static const String checkCompletedTab = 'Check the Completed tab to review your completed checklists.';
 }
 

--- a/src/support_sphere/lib/data/models/checklist.dart
+++ b/src/support_sphere/lib/data/models/checklist.dart
@@ -3,24 +3,24 @@ import 'package:equatable/equatable.dart';
 class Checklist extends Equatable {
   final String id;
   final String title;
-  final String? description;
+  final String description;
   final int stepCount;
   final String frequency;
   final bool isCompleted;
   final DateTime? completedAt;
   final DateTime? dueDate;
-  final int? lastCompletedVersion;
+  final int lastCompletedVersion;
 
   const Checklist({
     required this.id,
     required this.title,
-    this.description,
+    required this.description,
     required this.stepCount,
     required this.frequency,
     required this.isCompleted,
     this.completedAt,
     this.dueDate,
-    this.lastCompletedVersion = 0,
+    required this.lastCompletedVersion,
   });
 
   @override

--- a/src/support_sphere/lib/data/models/checklist.dart
+++ b/src/support_sphere/lib/data/models/checklist.dart
@@ -1,26 +1,23 @@
 import 'package:equatable/equatable.dart';
+import 'package:support_sphere/data/models/frequency.dart';
 
 class Checklist extends Equatable {
   final String id;
   final String title;
-  final String description;
-  final int stepCount;
-  final String frequency;
-  final bool isCompleted;
+  final String? description;
+  final List<ChecklistSteps> steps;
+  final Frequency? frequency;
   final DateTime? completedAt;
-  final DateTime? dueDate;
-  final int lastCompletedVersion;
+  final DateTime updatedAt;
 
   const Checklist({
     required this.id,
     required this.title,
-    required this.description,
-    required this.stepCount,
-    required this.frequency,
-    required this.isCompleted,
+    this.description = '',
+    this.steps = const [],
+    this.frequency,
     this.completedAt,
-    this.dueDate,
-    required this.lastCompletedVersion,
+    required this.updatedAt
   });
 
   @override
@@ -28,11 +25,37 @@ class Checklist extends Equatable {
     id,
     title,
     description,
-    stepCount,
+    steps,
     frequency,
-    isCompleted,
     completedAt,
-    dueDate,
-    lastCompletedVersion,
+    updatedAt
+  ];
+}
+
+class ChecklistSteps extends Equatable {
+  final String id;
+  final int priority;
+  final String? label;
+  final String? description;
+  final bool isCompleted;
+  final DateTime updatedAt;
+
+  const ChecklistSteps({
+    required this.id,
+    required this.priority,
+    this.label = '',
+    this.description = '',
+    required this.isCompleted,
+    required this.updatedAt
+  });
+
+  @override
+  List<Object?> get props => [
+    id,
+    priority,
+    label,
+    description,
+    isCompleted,
+    updatedAt
   ];
 }

--- a/src/support_sphere/lib/data/models/checklist.dart
+++ b/src/support_sphere/lib/data/models/checklist.dart
@@ -1,0 +1,38 @@
+import 'package:equatable/equatable.dart';
+
+class Checklist extends Equatable {
+  final String id;
+  final String title;
+  final String? description;
+  final int stepCount;
+  final String frequency;
+  final bool isCompleted;
+  final DateTime? completedAt;
+  final DateTime? dueDate;
+  final int? lastCompletedVersion;
+
+  const Checklist({
+    required this.id,
+    required this.title,
+    this.description,
+    required this.stepCount,
+    required this.frequency,
+    required this.isCompleted,
+    this.completedAt,
+    this.dueDate,
+    this.lastCompletedVersion = 0,
+  });
+
+  @override
+  List<Object?> get props => [
+    id,
+    title,
+    description,
+    stepCount,
+    frequency,
+    isCompleted,
+    completedAt,
+    dueDate,
+    lastCompletedVersion,
+  ];
+}

--- a/src/support_sphere/lib/data/models/frequency.dart
+++ b/src/support_sphere/lib/data/models/frequency.dart
@@ -1,0 +1,16 @@
+import 'package:equatable/equatable.dart';
+
+class Frequency extends Equatable {
+  final String id;
+  final String? name;
+  final int? numDays;
+
+  const Frequency({
+    required this.id,
+    this.name,
+    this.numDays,
+  });
+
+  @override
+  List<Object?> get props => [id, name, numDays];
+}

--- a/src/support_sphere/lib/data/repositories/checklist.dart
+++ b/src/support_sphere/lib/data/repositories/checklist.dart
@@ -1,0 +1,35 @@
+import 'package:support_sphere/data/models/checklist.dart';
+import 'package:support_sphere/data/services/checklist_service.dart';
+
+/// Repository for checklist interactions.
+/// This class is responsible for handling checklist-related data operations.
+class ChecklistRepository {
+  final ChecklistService _checklistService = ChecklistService();
+
+  /// Get user checklists by user id.
+  /// Returns a list of [Checklist] objects.
+  Future<List<Checklist>> getUserChecklists(String userId) async {
+    final data = await _checklistService.getUserChecklists(userId);
+    
+    return data.map((item) {
+      final recurringType = item['frequency'];
+      final checklistState = item['user_checklist_state'];
+      
+      return Checklist(
+        id: item['id'],
+        title: item['title'],
+        description: item['description'],
+        stepCount: item['checklist_steps']?.length ?? 0,
+        frequency: recurringType['name'],
+        isCompleted: checklistState?['completed'] ?? false,
+        completedAt: checklistState?['completed_at'] != null 
+            ? DateTime.parse(checklistState['completed_at'])
+            : null,
+        dueDate: item['due_date'] != null 
+            ? DateTime.parse(item['due_date'])
+            : null,
+        lastCompletedVersion: item['last_completed_version'],
+      );
+    }).toList();
+  }
+}

--- a/src/support_sphere/lib/data/repositories/checklist.dart
+++ b/src/support_sphere/lib/data/repositories/checklist.dart
@@ -17,10 +17,10 @@ class ChecklistRepository {
       
       return Checklist(
         id: item['id'],
-        title: item['title'],
-        description: item['description'],
+        title: item['title'] ?? '',
+        description: item['description'] ?? '',
         stepCount: item['checklist_steps']?.length ?? 0,
-        frequency: recurringType['name'],
+        frequency: recurringType['name'] ?? '',
         isCompleted: checklistState?['completed'] ?? false,
         completedAt: checklistState?['completed_at'] != null 
             ? DateTime.parse(checklistState['completed_at'])
@@ -28,7 +28,7 @@ class ChecklistRepository {
         dueDate: item['due_date'] != null 
             ? DateTime.parse(item['due_date'])
             : null,
-        lastCompletedVersion: item['last_completed_version'],
+        lastCompletedVersion: item['last_completed_version'] ?? 0,
       );
     }).toList();
   }

--- a/src/support_sphere/lib/data/services/checklist_service.dart
+++ b/src/support_sphere/lib/data/services/checklist_service.dart
@@ -1,0 +1,109 @@
+// import 'package:supabase_flutter/supabase_flutter.dart';
+// import 'package:support_sphere/utils/supabase.dart';
+
+class ChecklistService {
+  // final SupabaseClient _supabaseClient = supabase;
+
+  Future<List<Map<String, dynamic>>> getUserChecklists(String userId) async {
+    return [
+      {
+        "id": "78b00368-02e0-4e0d-a68c-8d08b123e083",
+        "title": "Personal Emergency Preparedness",
+        "description":
+            "This checklist helps individuals prepare for a variety of emergency situations, from natural disasters to unexpected crises, ensuring they have the necessary resources and plans in place to stay safe.",
+        "checklist_steps": [
+          {
+            "step": "Assemble an Emergency Kit",
+            "description":
+                "Collect essential supplies like food, water, medications, flashlights, and a first aid kit. Aim for a 72-hour supply to sustain you during the initial phase of an emergency."
+          },
+          {
+            "step": "Create a Family Communication Plan",
+            "description":
+                "Establish a way to communicate with family members during an emergency, including identifying a central contact person outside the area for everyone to check in with."
+          },
+          {
+            "step": "Know Your Local Risks",
+            "description":
+                "Identify specific risks in your area, such as hurricanes, earthquakes, or flooding, to better tailor your emergency preparations."
+          },
+          {
+            "step": "Learn Basic First Aid and CPR",
+            "description":
+                "Familiarize yourself with first aid and CPR techniques, which can be crucial during emergencies if immediate medical help isn’t available."
+          },
+          {
+            "step": "Secure Important Documents",
+            "description":
+                "Gather and protect important documents, like identification, insurance policies, and medical records, storing them in a waterproof, fireproof container."
+          }
+        ],
+        "last_completed_version": 1,
+        "frequency": {
+          "name": "Yearly",
+        },
+        "user_checklist_state": {
+          "completed": true,
+          "completed_at": DateTime.now().toString(),
+        }
+      },
+      {
+        "id": "edd1062d-0d1e-4b07-ab13-6775bf876a60",
+        "title": "Workplace Emergency Preparedness",
+        "description":
+            "This checklist is designed for businesses and organizations to help staff prepare for emergencies, minimizing risk and ensuring a quick, organized response to keep everyone safe.",
+        "checklist_steps": [
+          {
+            "step": "Develop an Emergency Response Plan",
+            "description":
+                "Create a comprehensive response plan detailing evacuation routes, shelter-in-place procedures, and communication protocols."
+          },
+          {
+            "step": "Conduct Regular Drills",
+            "description":
+                "Schedule drills for various scenarios like fire, earthquake, or active shooter situations to ensure employees know what to do in an emergency."
+          },
+          {
+            "step": "Establish a Communication Chain",
+            "description":
+                "Identify key personnel responsible for communicating updates during an emergency and establish clear methods for reaching all employees."
+          }
+        ],
+        "last_completed_version": 0,
+        "frequency": {
+          "name": "Once",
+        },
+        "user_checklist_state": {
+          "completed": true,
+          "completed_at": DateTime.now().toString(),
+        }
+      }
+    ];
+    /// TBD: on hold and wait until the PR is merged: https://github.com/uw-ssec/post-disaster-comms/pull/182
+    // return await _supabaseClient
+    //     .from('user_checklists')
+    //     .select('''
+    //       id,
+    //       checklist_type:checklist_types (
+    //         id,
+    //         title,
+    //         description,
+    //         recurring_type:recurring_types (
+    //           name,
+    //           num_days
+    //         ),
+    //         checklist_steps_order (
+    //           checklist_steps_templates_id
+    //         )
+    //       ),
+    //       due_date,
+    //       last_completed_version,
+    //       user_checklist_state (
+    //         completed,
+    //         completed_at
+    //       )
+    //     ''')
+    //     .eq('user_id', userId)
+    //     .order('due_date', ascending: true);
+  }
+}

--- a/src/support_sphere/lib/data/services/checklist_service.dart
+++ b/src/support_sphere/lib/data/services/checklist_service.dart
@@ -1,109 +1,48 @@
-// import 'package:supabase_flutter/supabase_flutter.dart';
-// import 'package:support_sphere/utils/supabase.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:support_sphere/utils/supabase.dart';
 
 class ChecklistService {
-  // final SupabaseClient _supabaseClient = supabase;
+  final SupabaseClient _supabaseClient = supabase;
 
   Future<List<Map<String, dynamic>>> getUserChecklists(String userId) async {
-    return [
-      {
-        "id": "78b00368-02e0-4e0d-a68c-8d08b123e083",
-        "title": "Personal Emergency Preparedness",
-        "description":
-            "This checklist helps individuals prepare for a variety of emergency situations, from natural disasters to unexpected crises, ensuring they have the necessary resources and plans in place to stay safe.",
-        "checklist_steps": [
-          {
-            "step": "Assemble an Emergency Kit",
-            "description":
-                "Collect essential supplies like food, water, medications, flashlights, and a first aid kit. Aim for a 72-hour supply to sustain you during the initial phase of an emergency."
-          },
-          {
-            "step": "Create a Family Communication Plan",
-            "description":
-                "Establish a way to communicate with family members during an emergency, including identifying a central contact person outside the area for everyone to check in with."
-          },
-          {
-            "step": "Know Your Local Risks",
-            "description":
-                "Identify specific risks in your area, such as hurricanes, earthquakes, or flooding, to better tailor your emergency preparations."
-          },
-          {
-            "step": "Learn Basic First Aid and CPR",
-            "description":
-                "Familiarize yourself with first aid and CPR techniques, which can be crucial during emergencies if immediate medical help isn’t available."
-          },
-          {
-            "step": "Secure Important Documents",
-            "description":
-                "Gather and protect important documents, like identification, insurance policies, and medical records, storing them in a waterproof, fireproof container."
-          }
-        ],
-        "last_completed_version": 1,
-        "frequency": {
-          "name": "Yearly",
-        },
-        "user_checklist_state": {
-          "completed": true,
-          "completed_at": DateTime.now().toString(),
-        }
-      },
-      {
-        "id": "edd1062d-0d1e-4b07-ab13-6775bf876a60",
-        "title": "Workplace Emergency Preparedness",
-        "description":
-            "This checklist is designed for businesses and organizations to help staff prepare for emergencies, minimizing risk and ensuring a quick, organized response to keep everyone safe.",
-        "checklist_steps": [
-          {
-            "step": "Develop an Emergency Response Plan",
-            "description":
-                "Create a comprehensive response plan detailing evacuation routes, shelter-in-place procedures, and communication protocols."
-          },
-          {
-            "step": "Conduct Regular Drills",
-            "description":
-                "Schedule drills for various scenarios like fire, earthquake, or active shooter situations to ensure employees know what to do in an emergency."
-          },
-          {
-            "step": "Establish a Communication Chain",
-            "description":
-                "Identify key personnel responsible for communicating updates during an emergency and establish clear methods for reaching all employees."
-          }
-        ],
-        "last_completed_version": 0,
-        "frequency": {
-          "name": "Once",
-        },
-        "user_checklist_state": {
-          "completed": true,
-          "completed_at": DateTime.now().toString(),
-        }
-      }
-    ];
-    /// TBD: on hold and wait until the PR is merged: https://github.com/uw-ssec/post-disaster-comms/pull/182
-    // return await _supabaseClient
-    //     .from('user_checklists')
-    //     .select('''
-    //       id,
-    //       checklist_type:checklist_types (
-    //         id,
-    //         title,
-    //         description,
-    //         recurring_type:recurring_types (
-    //           name,
-    //           num_days
-    //         ),
-    //         checklist_steps_order (
-    //           checklist_steps_templates_id
-    //         )
-    //       ),
-    //       due_date,
-    //       last_completed_version,
-    //       user_checklist_state (
-    //         completed,
-    //         completed_at
-    //       )
-    //     ''')
-    //     .eq('user_id', userId)
-    //     .order('due_date', ascending: true);
+    return await _supabaseClient
+        .from('user_checklists')
+        .select('''
+          id,
+          user_profile_id,
+          completed_at,
+          checklists (
+            id,
+            title,
+            description,
+            notes,
+            updated_at,
+            frequency (
+              id,
+              name,
+              num_days
+            ),
+            checklist_steps_orders (
+              id,
+              priority,
+              checklist_steps (
+                id,
+                label,
+                description,
+                updated_at
+              ),
+              checklist_steps_states (
+                id,
+                user_profile_id,
+                is_completed
+              )
+            )
+          )
+        ''')
+        .eq('user_profile_id', userId)
+        .eq('checklists.checklist_steps_orders.checklist_steps_states.user_profile_id', userId)
+        .order('priority',
+            referencedTable: 'checklists.checklist_steps_orders',
+            ascending: true);
   }
 }

--- a/src/support_sphere/lib/logic/cubit/checklist_cubit.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_cubit.dart
@@ -17,13 +17,17 @@ class ChecklistCubit extends Cubit<ChecklistState> {
   Future<void> fetchUserChecklists(String userId) async {
     try {
       final checklists = await _checklistRepository.getUserChecklists(userId);
-      
+
       emit(state.copyWith(
-        checklists: checklists,
-      ));
+          toBeDoneChecklists: checklists
+              .where((checklist) => checklist.completedAt == null)
+              .toList(),
+          completedChecklists: checklists
+              .where((checklist) => checklist.completedAt != null)
+              .toList()));
     } catch (error) {
       /// TBD: handle errors
+      print(error);
     }
   }
-
 }

--- a/src/support_sphere/lib/logic/cubit/checklist_cubit.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_cubit.dart
@@ -1,0 +1,29 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:support_sphere/data/models/auth_user.dart';
+import 'package:support_sphere/data/models/checklist.dart';
+import 'package:support_sphere/data/repositories/checklist.dart';
+
+part 'checklist_state.dart';
+
+class ChecklistCubit extends Cubit<ChecklistState> {
+  ChecklistCubit(this.authUser) : super(const ChecklistState()) {
+    fetchUserChecklists(authUser.uuid);
+  }
+
+  final AuthUser authUser;
+  final ChecklistRepository _checklistRepository = ChecklistRepository();
+
+  Future<void> fetchUserChecklists(String userId) async {
+    try {
+      final checklists = await _checklistRepository.getUserChecklists(userId);
+      
+      emit(state.copyWith(
+        checklists: checklists,
+      ));
+    } catch (error) {
+      /// TBD: handle errors
+    }
+  }
+
+}

--- a/src/support_sphere/lib/logic/cubit/checklist_state.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_state.dart
@@ -3,19 +3,23 @@ part of 'checklist_cubit.dart';
 /// handle checklist main page state
 class ChecklistState extends Equatable {
   const ChecklistState({
-    this.checklists = const [],
+    this.toBeDoneChecklists = const [],
+    this.completedChecklists = const [],
   });
   
-  final List<Checklist> checklists;
+  final List<Checklist> toBeDoneChecklists;
+  final List<Checklist> completedChecklists;
 
   @override
-  List<Object?> get props => [checklists];
+  List<Object?> get props => [toBeDoneChecklists, completedChecklists];
 
   ChecklistState copyWith({
-    List<Checklist>? checklists,
+    List<Checklist>? toBeDoneChecklists,
+    List<Checklist>? completedChecklists,
   }) {
     return ChecklistState(
-      checklists: checklists ?? this.checklists,
+      toBeDoneChecklists: toBeDoneChecklists ?? this.toBeDoneChecklists,
+      completedChecklists: completedChecklists ?? this.completedChecklists,
     );
   }
 }

--- a/src/support_sphere/lib/logic/cubit/checklist_state.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_state.dart
@@ -1,0 +1,21 @@
+part of 'checklist_cubit.dart';
+
+/// handle checklist main page state
+class ChecklistState extends Equatable {
+  const ChecklistState({
+    this.checklists = const [],
+  });
+  
+  final List<Checklist> checklists;
+
+  @override
+  List<Object?> get props => [checklists];
+
+  ChecklistState copyWith({
+    List<Checklist>? checklists,
+  }) {
+    return ChecklistState(
+      checklists: checklists ?? this.checklists,
+    );
+  }
+}

--- a/src/support_sphere/lib/presentation/components/checklist_card.dart
+++ b/src/support_sphere/lib/presentation/components/checklist_card.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
 
 class ChecklistCard extends StatelessWidget {
   final String title;
-  final int stepCount;
-  final String frequency;
-  final String description;
+  final String? frequency;
+  final int? stepCount;
+  final String? description;
   final bool isInProgress;
   final DateTime? completedDate;
   final VoidCallback onButtonClicked;
@@ -13,8 +14,8 @@ class ChecklistCard extends StatelessWidget {
   const ChecklistCard({
     super.key,
     required this.title,
-    required this.stepCount,
-    required this.frequency,
+    this.stepCount = 0,
+    this.frequency = '',
     this.description = '',
     this.onButtonClicked = _defaultButtonClicked,
     this.isInProgress = false,
@@ -39,28 +40,30 @@ class ChecklistCard extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
                 const SizedBox(height: 8),
-                Row(
-                  children: [
+                Row(children: [
+                  if (stepCount != null && stepCount != 0) ...[
                     const Icon(Icons.check_circle_outline, size: 16),
                     const SizedBox(width: 3),
-                    Text(ChecklistStrings.stepsCount(stepCount)),
-                    const SizedBox(width: 16),
+                    Text(ChecklistStrings.stepsCount(stepCount!))
+                  ],
+                  const SizedBox(width: 16),
+                  if (frequency != null && frequency!.isNotEmpty) ...[
                     const Icon(Icons.calendar_today, size: 16),
                     const SizedBox(width: 4),
-                    Text(frequency),
-                  ],
-                ),
+                    Text(frequency!)
+                  ]
+                ]),
                 if (completedDate != null) ...[
-                  const SizedBox(height: 4),
+                  const SizedBox(height: 5),
                   Text(
                     ChecklistStrings.completedOnDate(
-                        _formatDate(completedDate!)),
+                      DateFormat.yMMMd('en').format(completedDate!)),
                     style: Theme.of(context).textTheme.bodySmall,
                   ),
                 ],
-                const SizedBox(height: 8),
+                const SizedBox(height: 10),
                 Text(
-                  description,
+                  description ?? '',
                   style: Theme.of(context).textTheme.bodyMedium,
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
@@ -68,7 +71,7 @@ class ChecklistCard extends StatelessWidget {
               ],
             ),
           ),
-          if (isInProgress)
+          if (stepCount != null && stepCount! > 0 && isInProgress)
             Positioned(
               top: 0,
               right: 0,
@@ -87,11 +90,6 @@ class ChecklistCard extends StatelessWidget {
         ]),
       ),
     );
-  }
-
-  String _formatDate(DateTime date) {
-    // TODO: update proper date formatting
-    return date.toString().split(' ')[0];
   }
 
   static void _defaultButtonClicked() {}

--- a/src/support_sphere/lib/presentation/components/checklist_card.dart
+++ b/src/support_sphere/lib/presentation/components/checklist_card.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
+
+class ChecklistCard extends StatelessWidget {
+  final String title;
+  final int stepCount;
+  final String frequency;
+  final String description;
+  final bool isInProgress;
+  final DateTime? completedDate;
+  final VoidCallback onButtonClicked;
+
+  const ChecklistCard({
+    super.key,
+    required this.title,
+    required this.stepCount,
+    required this.frequency,
+    this.description = '',
+    this.onButtonClicked = _defaultButtonClicked,
+    this.isInProgress = false,
+    this.completedDate,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: InkWell(
+        onTap: onButtonClicked,
+        child: Stack(children: [
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.titleMedium,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    const Icon(Icons.check_circle_outline, size: 16),
+                    const SizedBox(width: 3),
+                    Text(ChecklistStrings.stepsCount(stepCount)),
+                    const SizedBox(width: 16),
+                    const Icon(Icons.calendar_today, size: 16),
+                    const SizedBox(width: 4),
+                    Text(frequency),
+                  ],
+                ),
+                if (completedDate != null) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    ChecklistStrings.completedOnDate(
+                        _formatDate(completedDate!)),
+                    style: Theme.of(context).textTheme.bodySmall,
+                  ),
+                ],
+                const SizedBox(height: 8),
+                Text(
+                  description,
+                  style: Theme.of(context).textTheme.bodyMedium,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
+            ),
+          ),
+          if (isInProgress)
+            Positioned(
+              top: 0,
+              right: 0,
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.secondaryContainer,
+                  borderRadius: BorderRadius.circular(4),
+                ),
+                child: const Text(
+                  ChecklistStrings.inProgress,
+                  style: TextStyle(fontSize: 11),
+                ),
+              ),
+            ),
+        ]),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    // TODO: update proper date formatting
+    return date.toString().split(' ')[0];
+  }
+
+  static void _defaultButtonClicked() {}
+}

--- a/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_main_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_main_body.dart
@@ -66,7 +66,7 @@ class _ToBeDoneTab extends StatelessWidget {
               title: checklist.title,
               stepCount: checklist.stepCount,
               frequency: checklist.frequency,
-              description: checklist.description ?? '',
+              description: checklist.description,
               isInProgress: checklist.lastCompletedVersion > 0,
               onButtonClicked: () {
                 // TODO: Navigate to checklist detail page
@@ -104,7 +104,7 @@ class _CompletedTab extends StatelessWidget {
               title: checklist.title,
               stepCount: checklist.stepCount,
               frequency: checklist.frequency,
-              description: checklist.description ?? '',
+              description: checklist.description,
               completedDate: checklist.completedAt,
               onButtonClicked: () {
                 // TODO: Navigate to completed checklist review

--- a/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_main_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_main_body.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:support_sphere/presentation/components/checklist_card.dart';
+import 'package:support_sphere/logic/cubit/checklist_cubit.dart';
+import 'package:support_sphere/logic/bloc/auth/authentication_bloc.dart';
+import 'package:support_sphere/data/models/auth_user.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
+
+class ChecklistBody extends StatelessWidget {
+  const ChecklistBody({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final AuthUser authUser = context.select(
+      (AuthenticationBloc bloc) => bloc.state.user,
+    );
+
+    return BlocProvider(
+      create: (context) => ChecklistCubit(authUser),
+      child: const DefaultTabController(
+        length: 2,
+        child: Column(
+          children: [
+            TabBar(
+              tabs: const [
+                Tab(text: ChecklistStrings.toBeDone),
+                Tab(text: ChecklistStrings.completed),
+              ],
+            ),
+            Expanded(
+              child: TabBarView(
+                children: [
+                  _ToBeDoneTab(),
+                  _CompletedTab(),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ToBeDoneTab extends StatelessWidget {
+  const _ToBeDoneTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ChecklistCubit, ChecklistState>(
+      builder: (context, state) {
+        final incompletedChecklists = state.checklists
+            .where((checklist) => !checklist.isCompleted)
+            .toList();
+
+        if (incompletedChecklists.isEmpty) {
+          return const _AllDoneView();
+        }
+
+        return ListView.builder(
+          itemCount: incompletedChecklists.length,
+          itemBuilder: (context, index) {
+            final checklist = incompletedChecklists[index];
+
+            return ChecklistCard(
+              title: checklist.title,
+              stepCount: checklist.stepCount,
+              frequency: checklist.frequency,
+              description: checklist.description ?? '',
+              isInProgress: checklist.lastCompletedVersion > 0,
+              onButtonClicked: () {
+                // TODO: Navigate to checklist detail page
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _CompletedTab extends StatelessWidget {
+  const _CompletedTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ChecklistCubit, ChecklistState>(
+      builder: (context, state) {
+        final completedChecklists = state.checklists
+            .where((checklist) => checklist.isCompleted)
+            .toList();
+
+        if (completedChecklists.isEmpty) {
+          return const Center(
+            child: Text(ChecklistStrings.noCompletedChecklist),
+          );
+        }
+
+        return ListView.builder(
+          itemCount: completedChecklists.length,
+          itemBuilder: (context, index) {
+            final checklist = completedChecklists[index];
+            return ChecklistCard(
+              title: checklist.title,
+              stepCount: checklist.stepCount,
+              frequency: checklist.frequency,
+              description: checklist.description ?? '',
+              completedDate: checklist.completedAt,
+              onButtonClicked: () {
+                // TODO: Navigate to completed checklist review
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+class _AllDoneView extends StatelessWidget {
+  const _AllDoneView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              ChecklistStrings.allDone,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 16),
+            Text(
+              ChecklistStrings.congratulations(
+                  '2024/11/12'), // Replace it with real data
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              ChecklistStrings.checkCompletedTab,
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/support_sphere/pubspec.lock
+++ b/src/support_sphere/pubspec.lock
@@ -419,7 +419,7 @@ packages:
     source: hosted
     version: "4.0.2"
   intl:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: intl
       sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf

--- a/src/support_sphere/pubspec.yaml
+++ b/src/support_sphere/pubspec.yaml
@@ -53,6 +53,7 @@ dependencies:
   form_builder_validators: ^11.0.0
   font_awesome_flutter: ^10.7.0
   flutter_form_builder: ^9.5.0
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This pull request introduces a comprehensive checklist feature to the Support Sphere app, including new models, repository, service, cubit, and UI components. The changes are organized into several themes: adding new models, updating the repository and service, implementing state management with Cubit, and updating the UI.

### New Models:
* [`src/support_sphere/lib/data/models/checklist.dart`](diffhunk://#diff-7d28a60a377ce6079cee0c1b7095523994c05db01a769d57104fd5bf8d15a569R1-R61): Added `Checklist` and `ChecklistSteps` models to represent checklists and their steps.
* [`src/support_sphere/lib/data/models/frequency.dart`](diffhunk://#diff-a0c5862e1a466fa27c60ae510e0d1e99b60905863bb80170864bc5487c546d66R1-R16): Added `Frequency` model to represent the frequency of checklists.

### Repository and Service:
* [`src/support_sphere/lib/data/repositories/checklist.dart`](diffhunk://#diff-19f84eecb3a5980cec787bf65f0a186bedbbc9f8492937f509f3bc52ed7a0a7cR1-R46): Created `ChecklistRepository` to handle checklist-related data operations.
* [`src/support_sphere/lib/data/services/checklist_service.dart`](diffhunk://#diff-089211716db7a731e641763326f555ae56a77ce0059d0f0c4b43a51f22244007R1-R48): Created `ChecklistService` to interact with the Supabase client and fetch user checklists.

### State Management:
* [`src/support_sphere/lib/logic/cubit/checklist_cubit.dart`](diffhunk://#diff-043e8341304beb1c94760d3292d0d5a53544b10b6ce7b744d20c96e975eb163dR1-R33): Implemented `ChecklistCubit` to manage the state of checklists.
* [`src/support_sphere/lib/logic/cubit/checklist_state.dart`](diffhunk://#diff-dd572e6389e1872ebed95c998e718b46d3585a2c3e68e09d6bcb6b955a156aecR1-R25): Defined `ChecklistState` to handle the state of the checklist main page.

### UI Components:
* [`src/support_sphere/lib/presentation/components/checklist_card.dart`](diffhunk://#diff-0dd94d14519299af52ab10acdf001dc6fba175c46bf5e04c0281a07a285a95e3R1-R96): Added `ChecklistCard` widget to display individual checklists.
* [`src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_main_body.dart`](diffhunk://#diff-ea40a36ab01761c090096310715183df61698c41acff39fce8972f3d9cc02af9R1-R169): Implemented `ChecklistBody` and its associated tabs for displaying to-be-done and completed checklists.

### Other Changes:
* [`src/support_sphere/lib/constants/routes.dart`](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39R6): Updated routes to include the new checklist feature.
* [`src/support_sphere/lib/constants/string_catalog.dart`](diffhunk://#diff-9663c9e5e9c15a602ae60e64b7178cbfd727abbac179b5aaefcab70a956373fdL4-R20): Added new strings for checklist messages and reformatted existing strings for better readability.
* [`src/support_sphere/pubspec.yaml`](diffhunk://#diff-4db6703e1a00162c625ec19e59f4ac28dee1c4bff679671a04cd257810e19262R56): Added `intl` dependency for date formatting.

### Related Issue
Resolves #140 

Regarding the original UI requirements, I made some adjustments. Instead of start & continue buttons, I enabled the tab feature on the cards themselves, which is more intuitive and aligned with the material design.

I inserted sample data into `frequency` table manually, which can be written in scripts in the future:
<img width="731" alt="Screenshot 2024-11-18 at 00 47 26" src="https://github.com/user-attachments/assets/162bf70a-cfb9-4ed8-8b66-4dc424549c24">

### DEMO
<img width="300" alt="Screenshot 2024-11-18 at 00 54 56" src="https://github.com/user-attachments/assets/119f8254-4a0e-4601-8d9f-a5c82e9fb556">
<img width="300" alt="Screenshot 2024-11-18 at 00 48 31" src="https://github.com/user-attachments/assets/c2ee0e48-1b9d-401b-91fd-48f720c8f035">
<img width="300" alt="Screenshot 2024-11-18 at 00 48 07" src="https://github.com/user-attachments/assets/5b98cc78-1eee-40a7-a1e8-d939f89d65cf">
<img width="300" alt="Screenshot 2024-11-18 at 00 48 14" src="https://github.com/user-attachments/assets/e7510ec4-d288-4646-b451-fab718f6d394">
<img width="300" alt="Screenshot 2024-11-18 at 00 45 43" src="https://github.com/user-attachments/assets/d1dd4f5c-d792-4ce3-b25b-f3a1ad6f6b10">
<img width="300" alt="Screenshot 2024-11-18 at 00 45 51" src="https://github.com/user-attachments/assets/47c99138-ac31-4984-b3b5-9e4cd6c735a2">

