### PR TITLE
chore: Fix update_db_sample_data setup sequence

### DIFF
--- a/src/support_sphere_py/src/support_sphere/scripts/update_db_sample_data.py
+++ b/src/support_sphere_py/src/support_sphere/scripts/update_db_sample_data.py
@@ -302,9 +302,6 @@ def test_app_mode_change():
 def run_all():
     logger.info("Starting to populate db with sample entries...")
 
-    # Setup utility resources to be shared during emergency
-    setup_utility_resources()
-
     # Sanity check for user sign-up and sign-in flow via supabase
     authenticate_user_signup_signin_signout_via_supabase()
 
@@ -313,6 +310,9 @@ def run_all():
 
     # Set up the database with dummy users, roles, and permissions
     setup_user_details()
+
+    # Setup utility resources to be shared during emergency
+    setup_utility_resources()
 
     # Sanity check app mode update
     test_app_mode_change()


### PR DESCRIPTION
## Reordering setup steps

* Moved the `setup_utility_resources()` call to occur after `setup_user_details()`.
* Without this adjustment, calling `populate_checklists` would `trigger the insert_user_checklists_for_all_users` trigger before user data has been set up, resulting in a failure to correctly insert into the `user_checklists` table.