### PR TITLE
feat: Add new/update preparedness checklist view

### DIFF
--- a/src/support_sphere/lib/constants/priority.dart
+++ b/src/support_sphere/lib/constants/priority.dart
@@ -1,0 +1,1 @@
+const List<String> priorityLevels = ['High', 'Medium', 'Low'];

--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -90,7 +90,19 @@ class ChecklistStrings {
       'Complete $frequencyName';
   static const String newChecklist = 'New Checklist';
   static const String manageChecklists = 'Manage Preparedness Checklists';
+  static const String addNewPreparednessChecklist = 'Add New Preparedness Checklist';
+  static const String editPreparednessChecklist = 'Edit Preparedness Checklist';
   static const String edit = 'Edit';
+  static const String save = 'Save';
+  static const String addNewStep = 'Add New Step';
+  static const String titleFieldLabel = 'Title*';
+  static const String frequencyFieldLabel = 'Frequency';
+  static const String priorityFieldLabel = 'Priority Level*';
+  static const String descriptionFieldLabel = 'Description* (Visible to all users)';
+  static const String notesFieldLabel = 'Notes (Visible only to LEAP steering committee)';
+  static const String stepLabelFieldLabel = 'Label*';
+  static const String stepDescriptionFieldLabel = 'Step Description';
+  static const String pleaseSelect = '-- Please Select --';
 }
 
 /// Error messages

--- a/src/support_sphere/lib/data/repositories/checklist.dart
+++ b/src/support_sphere/lib/data/repositories/checklist.dart
@@ -94,4 +94,58 @@ class ChecklistRepository {
           updatedAt: DateTime.parse(item['updated_at']));
     }).toList();
   }
+
+  Future<void> upsertChecklist(Checklist checklist) async {
+    final checklistData = {
+      'id': checklist.id,
+      'title': checklist.title,
+      'description': checklist.description,
+      'priority': checklist.priority.toUpperCase(),
+      'notes': checklist.notes,
+      'frequency_id': checklist.frequency?.id,
+      'updated_at': checklist.updatedAt!.toIso8601String(),
+    };
+
+    await _checklistService.upsertChecklist(checklistData);
+  }
+
+  Future<void> upsertChecklistSteps(
+      String checklistId, List<ChecklistSteps> steps) async {
+    final stepsData = steps
+        .map((step) => {
+              'id': step.id,
+              'label': step.label,
+              'description': step.description,
+              'updated_at': step.updatedAt!.toIso8601String(),
+            })
+        .toList();
+    final stepsOrdersData = steps
+        .map((step) => {
+              'id': step.orderId,
+              'checklist_id': checklistId,
+              'checklist_step_id': step.id,
+              'priority': step.priority,
+              'updated_at': step.updatedAt!.toIso8601String(),
+            })
+        .toList();
+
+    await _checklistService.upsertChecklistSteps(stepsData);
+    await _checklistService.upsertChecklistStepsOrders(stepsOrdersData);
+  }
+
+  Future<void> deleteChecklistSteps(String checklistId, List<String> stepIds) async {
+    await _checklistService.deleteChecklistSteps(checklistId, stepIds);
+  }
+
+  Future<List<Frequency>> getFrequencies() async {
+    final frequencies = await _checklistService.getFrequencies();
+
+    return frequencies
+        .map((freq) => Frequency(
+              id: freq['id'],
+              name: freq['name'],
+              numDays: freq['num_days'],
+            ))
+        .toList();
+  }
 }

--- a/src/support_sphere/lib/data/services/checklist_service.dart
+++ b/src/support_sphere/lib/data/services/checklist_service.dart
@@ -139,4 +139,36 @@ class ChecklistService {
         .update({'completed_at': completedAt?.toIso8601String()}).eq(
             'id', userChecklistId);
   }
+
+  Future<void> upsertChecklist(Map<String, dynamic> checklistData) async {
+    await _supabaseClient.from('checklists').upsert(checklistData);
+  }
+
+  Future<void> upsertChecklistSteps(
+      List<Map<String, Object?>> stepsData) async {
+    await _supabaseClient.from('checklist_steps').upsert(stepsData);
+  }
+
+  Future<void> upsertChecklistStepsOrders(
+      List<Map<String, Object?>> stepsOrdersData) async {
+    await _supabaseClient
+        .from('checklist_steps_orders')
+        .upsert(stepsOrdersData);
+  }
+
+  Future<List<Map<String, dynamic>>> getFrequencies() async {
+    return await _supabaseClient.from('frequency').select('''
+          id,
+          name,
+          num_days
+        ''').order('num_days', ascending: false);
+  }
+
+  Future<void> deleteChecklistSteps(String checklistId, List<String> stepIds) async {
+    /// The trigger will handle the cascade deletion
+    await _supabaseClient
+        .from('checklist_steps')
+        .delete()
+        .inFilter('id', stepIds);
+  }
 }

--- a/src/support_sphere/lib/logic/cubit/checklist_form_cubit.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_form_cubit.dart
@@ -1,0 +1,135 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:support_sphere/data/models/auth_user.dart';
+import 'package:support_sphere/data/models/checklist.dart';
+import 'package:support_sphere/data/models/frequency.dart';
+import 'package:support_sphere/data/repositories/checklist.dart';
+import 'package:uuid/v4.dart';
+
+part 'checklist_form_state.dart';
+
+class ChecklistFormCubit extends Cubit<ChecklistFormState> {
+  ChecklistFormCubit({required this.authUser, this.initialChecklist})
+      : super(ChecklistFormState(
+          steps: initialChecklist?.steps ?? const [],
+        )) {
+    fetchAllFrequencies();
+  }
+
+  final AuthUser authUser;
+  final Checklist? initialChecklist;
+  final ChecklistRepository _checklistRepository = ChecklistRepository();
+
+  void addStep() {
+    final steps = List<ChecklistSteps>.from(state.steps);
+
+    steps.add(ChecklistSteps(
+      id: const UuidV4().generate(),
+      orderId: const UuidV4().generate(),
+      priority: steps.length,
+    ));
+
+    emit(state.copyWith(steps: steps));
+  }
+
+  void removeStep(int index) {
+    final steps = List<ChecklistSteps>.from(state.steps);
+    steps.removeAt(index);
+
+    // Update priorities for remaining steps
+    for (var i = 0; i < steps.length; i++) {
+      steps[i] = ChecklistSteps(
+        id: steps[i].id,
+        orderId: steps[i].orderId,
+        priority: i,
+        label: steps[i].label,
+        description: steps[i].description,
+        updatedAt: steps[i].updatedAt,
+      );
+    }
+
+    emit(state.copyWith(steps: steps));
+  }
+
+  void reorderStep(int oldIndex, int newIndex) {
+    final steps = List<ChecklistSteps>.from(state.steps);
+    final step = steps.removeAt(oldIndex);
+    steps.insert(newIndex, step);
+
+    // Update priorities for all steps
+    for (var i = 0; i < steps.length; i++) {
+      steps[i] = ChecklistSteps(
+        id: steps[i].id,
+        orderId: steps[i].orderId,
+        priority: i,
+        label: steps[i].label,
+        description: steps[i].description,
+        updatedAt: steps[i].updatedAt,
+      );
+    }
+
+    emit(state.copyWith(steps: steps));
+  }
+
+  Future<void> fetchAllFrequencies() async {
+    try {
+      final frequencies = await _checklistRepository.getFrequencies();
+      emit(state.copyWith(frequencies: frequencies));
+    } catch (error) {
+      /// TODO: handle errors
+      print(error);
+    }
+  }
+
+  Future<void> saveChecklist(
+      {String? id, required Map<String, dynamic> formData}) async {
+    try {
+      emit(state.copyWith(status: ChecklistFormStatus.loading));
+
+      final checklistId = id ??
+          // insert new uuid when creating new checklist
+          const UuidV4().generate();
+      final checklist = Checklist(
+        id: checklistId,
+        title: formData['title'],
+        description: formData['description'],
+        notes: formData['notes'],
+        priority: formData['priority'],
+        frequency: state.frequencies
+            .where((freq) => freq.id == formData['frequency_id'])
+            .singleOrNull,
+        steps: state.steps,
+        updatedAt: DateTime.now(), // TODO: handle updated_at with DB Trigger
+      );
+      final steps = state.steps.map<ChecklistSteps>((step) {
+        return ChecklistSteps(
+          id: step.id,
+          orderId: step.orderId,
+          priority: step.priority,
+          label: formData['step_label_${step.id}'],
+          description: formData['step_description_${step.id}'],
+          updatedAt: DateTime.now(), // TODO: handle updated_at with DB Trigger
+        );
+      }).toList();
+
+      if (initialChecklist != null) {
+        final deletedStepIds = initialChecklist!.steps
+            .where((oldStep) => !steps.any((newStep) => newStep.id == oldStep.id))
+            .map((step) => step.id)
+            .toList();
+
+        if (deletedStepIds.isNotEmpty) {
+          await _checklistRepository.deleteChecklistSteps(checklistId, deletedStepIds);
+        }
+      }
+
+      await _checklistRepository.upsertChecklist(checklist);
+      await _checklistRepository.upsertChecklistSteps(checklistId, steps);
+
+      emit(state.copyWith(status: ChecklistFormStatus.success));
+    } catch (error) {
+      /// TODO: handle errors
+      print(error);
+    }
+  }
+}

--- a/src/support_sphere/lib/logic/cubit/checklist_form_state.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_form_state.dart
@@ -1,0 +1,40 @@
+part of 'checklist_form_cubit.dart';
+
+enum ChecklistFormStatus { initial, loading, success, failure }
+
+class ChecklistFormState extends Equatable {
+  final List<ChecklistSteps> steps;
+  final ChecklistFormStatus status;
+  final List<Frequency> frequencies;
+
+  const ChecklistFormState({
+    this.steps = const [],
+    this.status = ChecklistFormStatus.initial,
+    this.frequencies = const [],
+  });
+
+  @override
+  List<Object?> get props => [
+        steps,
+        status,
+        frequencies,
+      ];
+
+  ChecklistFormState copyWith({
+    List<ChecklistSteps>? steps,
+    ChecklistFormStatus? status,
+    List<Frequency>? frequencies,
+  }) {
+    return ChecklistFormState(
+      steps: steps ?? this.steps,
+      status: status ?? this.status,
+      frequencies: frequencies ?? this.frequencies,
+    );
+  }
+
+  /// TODO: use them to implement UI logic
+  bool get isInitial => status == ChecklistFormStatus.initial;
+  bool get isLoading => status == ChecklistFormStatus.loading;
+  bool get isSuccess => status == ChecklistFormStatus.success;
+  bool get isFailure => status == ChecklistFormStatus.failure;
+}

--- a/src/support_sphere/lib/logic/cubit/checklist_management_cubit.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_management_cubit.dart
@@ -25,4 +25,19 @@ class ChecklistManagementCubit extends Cubit<ChecklistManagementState> {
       print(error);
     }
   }
+
+  void showChecklistForm({Checklist? checklist}) {
+    emit(state.copyWith(
+      showForm: true,
+      // if there is no checklist, it means creating new checklist
+      editingChecklist: checklist,
+    ));
+  }
+
+  void hideChecklistForm() {
+    emit(state.copyWith(
+      showForm: false,
+      editingChecklist: null,
+    ));
+  }
 }

--- a/src/support_sphere/lib/logic/cubit/checklist_management_state.dart
+++ b/src/support_sphere/lib/logic/cubit/checklist_management_state.dart
@@ -5,19 +5,31 @@ class ChecklistManagementState extends Equatable {
   const ChecklistManagementState({
     this.allChecklists =
         const [], // for LEAP users, they can see all checklists instead of the checklists for a specific user
+    this.showForm = false,
+    this.editingChecklist,
   });
 
   final List<Checklist> allChecklists;
+  final bool showForm;
+  final Checklist? editingChecklist;
 
   @override
-  List<Object> get props =>
-      [allChecklists];
+  List<Object?> get props => [allChecklists, showForm, editingChecklist];
 
   ChecklistManagementState copyWith({
     List<Checklist>? allChecklists,
+    bool? showForm,
+    Checklist? editingChecklist,
   }) {
     return ChecklistManagementState(
       allChecklists: allChecklists ?? this.allChecklists,
+      showForm: showForm ?? this.showForm,
+      editingChecklist: editingChecklist,
+      /*
+        For editingChecklist, don't use ?? operator here because we want to allow null values to be set.
+        If we used ??, when editingChecklist is null, it would fallback to the previous value,
+        preventing us from clearing the editing state.
+      */
     );
   }
 }

--- a/src/support_sphere/lib/presentation/components/checklist/checklist_step_field.dart
+++ b/src/support_sphere/lib/presentation/components/checklist/checklist_step_field.dart
@@ -1,0 +1,103 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
+
+class ChecklistStepField extends StatelessWidget {
+  final String id;
+  final int index;
+  final int totalSteps;
+  final VoidCallback onRemove;
+  final VoidCallback? onMoveUp;
+  final VoidCallback? onMoveDown;
+  final String? initialLabel;
+  final String? initialDescription;
+
+  const ChecklistStepField({
+    super.key,
+    required this.id,
+    required this.index,
+    required this.totalSteps,
+    required this.onRemove,
+    this.onMoveUp,
+    this.onMoveDown,
+    this.initialLabel,
+    this.initialDescription,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final labelId = 'step_label_$id';
+    final descriptionId = 'step_description_$id';
+
+    return Card(
+      key: Key('step_$id'),
+      margin: const EdgeInsets.only(bottom: 16),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Text(
+                  'Step ${index + 1}',
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const Spacer(),
+
+                /// Action buttons
+                if (index > 0)
+                  IconButton(
+                    icon: const Icon(Icons.arrow_upward),
+                    onPressed: onMoveUp,
+                  ),
+                if (index < totalSteps - 1)
+                  IconButton(
+                    icon: const Icon(Icons.arrow_downward),
+                    onPressed: onMoveDown,
+                  ),
+                IconButton(
+                  icon: const Icon(Icons.delete),
+                  onPressed: onRemove,
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+
+            /// Step's label field
+            FormBuilderTextField(
+              key: Key(labelId),
+              name: labelId,
+              initialValue: initialLabel,
+              decoration: const InputDecoration(
+                labelText: ChecklistStrings.stepLabelFieldLabel,
+                border: OutlineInputBorder(),
+              ),
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(),
+                FormBuilderValidators.maxLength(200),
+              ]),
+            ),
+            const SizedBox(height: 16),
+
+            /// Step's description field
+            FormBuilderTextField(
+              key: Key(descriptionId),
+              name: descriptionId,
+              initialValue: initialDescription,
+              decoration: const InputDecoration(
+                labelText: ChecklistStrings.stepDescriptionFieldLabel,
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 3,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_management_form_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_management_form_body.dart
@@ -1,0 +1,240 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
+import 'package:support_sphere/data/models/checklist.dart';
+import 'package:support_sphere/logic/cubit/checklist_form_cubit.dart';
+import 'package:support_sphere/presentation/components/checklist/checklist_step_field.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/constants/priority.dart';
+import 'package:support_sphere/utils/extensions.dart';
+
+class ChecklistFormBody extends StatefulWidget {
+  const ChecklistFormBody({
+    super.key,
+    this.initialChecklist,
+    required this.onCancel,
+  });
+
+  final Checklist? initialChecklist;
+  final VoidCallback onCancel;
+
+  @override
+  State<ChecklistFormBody> createState() => _ChecklistFormBodyState();
+}
+
+class _ChecklistFormBodyState extends State<ChecklistFormBody> {
+  late final GlobalKey<FormBuilderState> _formKey;
+
+  @override
+  void initState() {
+    super.initState();
+    _formKey = GlobalKey<FormBuilderState>();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocListener<ChecklistFormCubit, ChecklistFormState>(
+      listener: (context, state) {
+        if (state.status == ChecklistFormStatus.success) {
+          widget.onCancel();
+        }
+      },
+      child: Column(
+        children: [
+          _buildAppBar(context),
+          Expanded(
+            child: _buildForm(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAppBar(BuildContext context) {
+    return AppBar(
+      leading: IconButton(
+        icon: const Icon(Icons.arrow_back),
+        onPressed: widget.onCancel,
+      ),
+      title: Text(
+        widget.initialChecklist != null
+            ? ChecklistStrings.editPreparednessChecklist
+            : ChecklistStrings.addNewPreparednessChecklist,
+      ),
+      actions: [
+        BlocBuilder<ChecklistFormCubit, ChecklistFormState>(
+          builder: (context, state) {
+            return Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: TextButton(
+                onPressed: state.status == ChecklistFormStatus.loading
+                    ? null
+                    : () {
+                        if (_formKey.currentState?.saveAndValidate() ?? false) {
+                          context.read<ChecklistFormCubit>().saveChecklist(
+                                id: widget.initialChecklist?.id,
+                                formData: _formKey.currentState!.value,
+                              );
+                        }
+                      },
+                child: const Text(ChecklistStrings.save),
+              ),
+            );
+          },
+        ),
+      ],
+    );
+  }
+
+  Widget _buildForm(BuildContext context) {
+    return FormBuilder(
+      key: _formKey,
+      child: SingleChildScrollView(
+        padding:
+            const EdgeInsets.only(left: 16, right: 16, top: 16, bottom: 32),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            /// Title field
+            FormBuilderTextField(
+              name: 'title',
+              initialValue: widget.initialChecklist?.title,
+              decoration: const InputDecoration(
+                labelText: ChecklistStrings.titleFieldLabel,
+                border: OutlineInputBorder(),
+              ),
+              validator: FormBuilderValidators.compose([
+                FormBuilderValidators.required(),
+                FormBuilderValidators.maxLength(100),
+              ]),
+            ),
+            const SizedBox(height: 16),
+
+            /// Frequency field
+            BlocBuilder<ChecklistFormCubit, ChecklistFormState>(
+              builder: (context, state) {
+                if (state.frequencies.isEmpty) {
+                  /// Show loading indicator while fetching frequencies
+                  return const CircularProgressIndicator();
+                }
+
+                return FormBuilderDropdown<String>(
+                  name: 'frequency_id',
+                  initialValue: widget.initialChecklist?.frequency?.id,
+                  decoration: const InputDecoration(
+                    labelText: ChecklistStrings.frequencyFieldLabel,
+                    border: OutlineInputBorder(),
+                  ),
+                  items: [
+                    const DropdownMenuItem(
+                      child: Text(ChecklistStrings.pleaseSelect),
+                    ),
+                    ...state.frequencies.map((frequency) {
+                      return DropdownMenuItem(
+                        value: frequency.id,
+                        child: Text(frequency.name ?? ''),
+                      );
+                    }),
+                  ],
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+
+            /// Priority level field
+            FormBuilderDropdown<String>(
+              name: 'priority',
+              initialValue: widget.initialChecklist?.priority.capitalize() ??
+                  priorityLevels[1],
+              decoration: const InputDecoration(
+                labelText: ChecklistStrings.priorityFieldLabel,
+                border: OutlineInputBorder(),
+              ),
+              items: priorityLevels.map((priority) {
+                return DropdownMenuItem(
+                  value: priority,
+                  child: Text(priority),
+                );
+              }).toList(),
+              validator: FormBuilderValidators.required(),
+            ),
+            const SizedBox(height: 16),
+
+            /// Description field
+            FormBuilderTextField(
+              name: 'description',
+              initialValue: widget.initialChecklist?.description,
+              decoration: const InputDecoration(
+                labelText: ChecklistStrings.descriptionFieldLabel,
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 3,
+              validator: FormBuilderValidators.required(),
+            ),
+            const SizedBox(height: 16),
+
+            /// Notes field
+            FormBuilderTextField(
+              name: 'notes',
+              initialValue: widget.initialChecklist?.notes,
+              decoration: const InputDecoration(
+                labelText: ChecklistStrings.notesFieldLabel,
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 3,
+            ),
+            const SizedBox(height: 16),
+
+            /// Steps section
+            BlocBuilder<ChecklistFormCubit, ChecklistFormState>(
+              builder: (context, state) {
+                return ListView.builder(
+                  shrinkWrap: true,
+                  /*
+                    Disable scrolling for this ListView since it's inside a SingleChildScrollView
+                    This prevents nested scrolling conflicts and ensures smooth scrolling experience
+                  */
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: state.steps.length,
+                  itemBuilder: (context, index) {
+                    final step = state.steps[index];
+                    return ChecklistStepField(
+                      id: step.id,
+                      index: index,
+                      totalSteps: state.steps.length,
+                      initialLabel: step.label,
+                      initialDescription: step.description,
+                      onRemove: () =>
+                          context.read<ChecklistFormCubit>().removeStep(index),
+                      onMoveUp: index > 0
+                          ? () => context
+                              .read<ChecklistFormCubit>()
+                              .reorderStep(index, index - 1)
+                          : null,
+                      onMoveDown: index < state.steps.length - 1
+                          ? () => context
+                              .read<ChecklistFormCubit>()
+                              .reorderStep(index, index + 1)
+                          : null,
+                    );
+                  },
+                );
+              },
+            ),
+            const SizedBox(height: 16),
+
+            /// Add new step button
+            Center(
+              child: ElevatedButton.icon(
+                onPressed: () => context.read<ChecklistFormCubit>().addStep(),
+                icon: const Icon(Icons.add),
+                label: const Text(ChecklistStrings.addNewStep),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces several new features and improvements to the checklist management functionality in the `support_sphere` project. The changes include adding new constants, enhancing the data repository and service layers, and implementing new cubit and UI components for checklist management.

### New Constants:
* Added `priorityLevels` constant in `priority.dart` to define priority levels.
* Added multiple new string constants in `string_catalog.dart` for checklist management labels and messages.

### Data Layer Enhancements:
* Added methods to `ChecklistRepository` for upserting checklists and steps, deleting steps, and fetching frequencies.
* Added corresponding methods in `ChecklistService` to interact with the database for the new repository methods.

### New Cubit and State for Checklist Form:
* Created `ChecklistFormCubit` to manage the state and actions related to the checklist form, including adding, removing, and reordering steps.
* Created `ChecklistFormState` to define the state of the checklist form, including step data and form status.

### UI Components:
* Implemented `ChecklistStepField` widget to represent individual steps in the checklist form.
* Created `ChecklistFormBody` to build the checklist form UI, including fields for title, frequency, priority, description, notes, and steps, as well as handling form submission and validation.

### Checklist Management Enhancements:
* Added methods to `ChecklistManagementCubit` to show and hide the checklist form.
* Updated `ChecklistManagementState` to include properties for form visibility and the checklist being edited.

### Related Issue
Resolves #143 

### DEMO
<img width="500" alt="Screenshot 2024-11-25 at 01 50 29" src="https://github.com/user-attachments/assets/becf0996-5e4e-4477-a9b7-71c752e5b71c">
<img width="500" alt="Screenshot 2024-11-25 at 01 52 34" src="https://github.com/user-attachments/assets/a6949f47-e6e1-4e80-8b04-4db562028030">
<img width="500" alt="Screenshot 2024-11-25 at 01 53 43" src="https://github.com/user-attachments/assets/c62e80f0-8970-4207-a55d-c4e732d06d7a">
<img width="500" alt="Screenshot 2024-11-25 at 01 53 55" src="https://github.com/user-attachments/assets/2648a6f3-4c61-41f2-9c57-b880f8554310">
<img width="500" alt="Screenshot 2024-11-25 at 01 54 13" src="https://github.com/user-attachments/assets/a575e126-cbe3-4a75-b3d2-d9ae665cdd5c">
<img width="500" alt="Screenshot 2024-11-25 at 01 54 41" src="https://github.com/user-attachments/assets/d1255cb7-7e3e-4f8c-a416-a59281c9f5d7">
