### PR TITLE
feat: Add minimum screen size media query

### DIFF
--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -17,7 +17,7 @@ class AppRoute extends Equatable {
 }
 
 class AppNavigation {
-  static List<AppRoute> getDestinations(String? role) {
+  static List<AppRoute> getDestinations(String? role, [double? minWidth]) {
     // TODO: Add body for each route
     List<AppRoute> destinations = [
       const AppRoute(
@@ -28,7 +28,7 @@ class AppNavigation {
           icon: Icon(Ionicons.shield_checkmark_sharp), label: NavRouteLabels.prepare, body: ChecklistBody()),
       const AppRoute(icon: Icon(Ionicons.hammer_sharp), label: NavRouteLabels.resources),
     ];
-    if (role == AppRoles.communityAdmin) {
+    if (role == AppRoles.communityAdmin && minWidth! > 641) {
       // TODO: Make this display only for certain screen size
       destinations = destinations + [
         const AppRoute(

--- a/src/support_sphere/lib/constants/routes.dart
+++ b/src/support_sphere/lib/constants/routes.dart
@@ -28,8 +28,11 @@ class AppNavigation {
           icon: Icon(Ionicons.shield_checkmark_sharp), label: NavRouteLabels.prepare, body: ChecklistBody()),
       const AppRoute(icon: Icon(Ionicons.hammer_sharp), label: NavRouteLabels.resources),
     ];
+    // Set the minimum width for managing resources and checklists
+    // to be displayed in the navigation bar
+    // screen size maximum information retrieved from
+    // https://learn.microsoft.com/en-us/windows/apps/design/layout/screen-sizes-and-breakpoints-for-responsive-design
     if (role == AppRoles.communityAdmin && minWidth! > 641) {
-      // TODO: Make this display only for certain screen size
       destinations = destinations + [
         const AppRoute(
             icon: Icon(Ionicons.construct_sharp), label: NavRouteLabels.manageResources),

--- a/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/app_page.dart
@@ -48,7 +48,8 @@ class AppPage extends StatelessWidget {
             final AuthUser authUser = context.select(
               (AuthenticationBloc bloc) => bloc.state.user,
             );
-            AppBodySelect bodySelector = AppBodySelect(role: authUser.userRole);
+            MediaQueryData screenData = MediaQuery.of(context);
+            AppBodySelect bodySelector = AppBodySelect(role: authUser.userRole, screenData: screenData);
             return SafeArea(
               child: Scaffold(
                 appBar: AppBar(

--- a/src/support_sphere/lib/presentation/router/app_body_select.dart
+++ b/src/support_sphere/lib/presentation/router/app_body_select.dart
@@ -3,12 +3,13 @@ import 'package:flutter/material.dart';
 import 'package:support_sphere/constants/routes.dart';
 
 class AppBodySelect extends Equatable {
-  const AppBodySelect({required this.role});
+  const AppBodySelect({required this.role, this.screenData});
 
   final String role;
+  final MediaQueryData? screenData;
 
   List<AppRoute> get destinations {
-    return AppNavigation.getDestinations(role);
+    return AppNavigation.getDestinations(role, screenData?.size.width);
   }
 
   @override


### PR DESCRIPTION
This pull request includes changes to the `src/support_sphere` library to enhance the app's navigation and body selection based on screen size. The most important changes include updating the `AppNavigation` and `AppBodySelect` classes to consider screen width, and modifying the `AppPage` class to pass screen data.

Enhancements to navigation and body selection:

* [`src/support_sphere/lib/constants/routes.dart`](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39L20-R20): Updated `AppNavigation.getDestinations` to accept an optional `minWidth` parameter and adjusted the logic to display certain routes only for specific screen sizes. [[1]](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39L20-R20) [[2]](diffhunk://#diff-cbff05c7ffb5e17adbd5bd2b934d0b73a29d29f625d413778ae7dfa43cda9d39L31-R31)
* [`src/support_sphere/lib/presentation/pages/main_app/app_page.dart`](diffhunk://#diff-4ec56a88127dcbb85de402b2cce9c6a17bf89ac1aec17aeac1426813b555e8bcL51-R52): Modified the `AppPage` class to retrieve `MediaQueryData` and pass it to `AppBodySelect`.
* [`src/support_sphere/lib/presentation/router/app_body_select.dart`](diffhunk://#diff-28ae89a9b54d492b98c11a89d0d6c58b0f6d1dc512f0009b9158314755ab8b5dL6-R12): Updated `AppBodySelect` to include an optional `screenData` parameter and use it when fetching destinations.

# Demo

IPhone

<img width="334" alt="Screenshot 2024-11-25 at 9 16 09 AM" src="https://github.com/user-attachments/assets/fb8758fe-3ac7-4c21-9f57-7be2339d70e6">

IPad

<img width="405" alt="Screenshot 2024-11-25 at 9 16 24 AM" src="https://github.com/user-attachments/assets/b2125a12-4cfe-4829-8b4b-d8beda00689d">

Desktop

<img width="1496" alt="Screenshot 2024-11-25 at 9 17 58 AM" src="https://github.com/user-attachments/assets/b22fb246-7e1e-4f79-8cb2-c359347925d4">


You can see from the demo above now the nav for managing stuff only shows up for medium size screen and above.