### PR TITLE
fix: Fix path to rendered files for web

### DIFF
--- a/.github/workflows/web-main.yaml
+++ b/.github/workflows/web-main.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Upload Pages HTML
       uses: actions/upload-pages-artifact@v3
       with:
-        path: build/web
+        path: src/support_sphere/build/web
 
     - name: Setup GitHub Pages
       uses: actions/configure-pages@v5
@@ -49,4 +49,4 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: build-${{ runner.os }}
-        path: build/web/
+        path: src/support_sphere/build/web/


### PR DESCRIPTION
This pull request includes changes to the `path` configuration in the GitHub Actions workflow file `.github/workflows/web-main.yaml`. The changes update the paths to reflect a new directory structure.

Changes in `jobs:` section:

* Updated the `path` for the "Upload Pages HTML" step to `src/support_sphere/build/web`.
* Updated the `path` for the "Upload artifact" step to `src/support_sphere/build/web/`.