### PR TITLE
fix: Fix permission for web gh-pages deployment

### DIFF
--- a/.github/workflows/web-main.yaml
+++ b/.github/workflows/web-main.yaml
@@ -1,5 +1,11 @@
 name: web
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 on:
   push:
     branches:
@@ -43,10 +49,3 @@ jobs:
     - name: Deploy to GitHub Pages
       id: deployment
       uses: actions/deploy-pages@v4
-
-    - name: Upload Complete Build Folder
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: build-${{ runner.os }}
-        path: src/support_sphere/build/web/


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow configuration for the web project to enhance deployment to GitHub Pages and simplify the workflow by removing an unnecessary step.

Enhancements to deployment permissions:

* [`.github/workflows/web-main.yaml`](diffhunk://#diff-a3f8bd0162b14f6fb1afb8f86d38616de0c34882b62e124baedc0701aba57027R3-R8): Added permissions for the `GITHUB_TOKEN` to allow deployment to GitHub Pages.

Simplification of deployment steps:

* [`.github/workflows/web-main.yaml`](diffhunk://#diff-a3f8bd0162b14f6fb1afb8f86d38616de0c34882b62e124baedc0701aba57027L46-L52): Removed the step to upload the complete build folder, as it is no longer needed.