### PR TITLE
build: Minify release web build and add base-href

### DIFF
--- a/.github/workflows/web-main.yaml
+++ b/.github/workflows/web-main.yaml
@@ -36,7 +36,13 @@ jobs:
         channel: stable
     - run: flutter pub get
     # original values are in deployment/values.cloud.yaml
-    - run: flutter build web --web-renderer html --dart-define=SUPABASE_ANON_KEY=${{ secrets.CLOUD_DB_JWT_ANON_KEY}} --dart-define=SUPABASE_URL=${{ secrets.CLOUD_DB_URL}} 
+    - run: |
+        flutter build web \
+        --release \
+        --base-href "/post-disaster-comms/" \
+        --web-renderer html \
+        --dart-define=SUPABASE_ANON_KEY=${{ secrets.CLOUD_DB_JWT_ANON_KEY}} \
+        --dart-define=SUPABASE_URL=${{ secrets.CLOUD_DB_URL}} 
 
     - name: Upload Pages HTML
       uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
This pull request includes changes to the `jobs:` section in the `.github/workflows/web-main.yaml` file to enhance the build process for the Flutter web application. The most important changes are:

* Added the `--release` flag to the Flutter build command to ensure the application is built in release mode.
* Included the `--base-href "/post-disaster-comms/"` option to set the base URL for the web application.