### PR TITLE
chore: Fix 'All Checklists' misspelling

### DIFF
--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -85,7 +85,7 @@ class ChecklistStrings {
       " It should be done again on $dateStr.";
   static const String checkCompletedTab =
       'Check the Completed tab to review your completed checklists.';
-  static const String allChecklist = 'All Checklist';
+  static const String allChecklist = 'All Checklists';
   static String completeFrequency(String frequencyName) =>
       'Complete $frequencyName';
   static const String newChecklist = 'New Checklist';


### PR DESCRIPTION
This pull request includes a minor change to the `src/support_sphere/lib/constants/string_catalog.dart` file. The change corrects a typo in the `allChecklist` string constant.

* [`src/support_sphere/lib/constants/string_catalog.dart`](diffhunk://#diff-9663c9e5e9c15a602ae60e64b7178cbfd727abbac179b5aaefcab70a956373fdL88-R88): Corrected the typo in the `allChecklist` string constant from 'All Checklist' to 'All Checklists'.

## Related Issues

Fixes #210