### PR TITLE
chore: Update default app name

### DIFF
--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -1,6 +1,6 @@
 /// Strings used in the app
 class AppStrings {
-  static const String appName = 'Support Sphere';
+  static const String appName = 'Resilience - Laurelhurst';
   static const String signUpWelcome =
       'Welcome to ${AppStrings.appName}\nCreate a new account and prepare with your community';
   static const String testEmergencyBannerText = "This is a test emergency.";

--- a/src/support_sphere/lib/presentation/components/icon_logo.dart
+++ b/src/support_sphere/lib/presentation/components/icon_logo.dart
@@ -1,6 +1,7 @@
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:ionicons/ionicons.dart';
 import 'package:flutter/material.dart';
+import 'package:support_sphere/constants/string_catalog.dart';
 
 class IconLogo extends StatelessWidget {
 const IconLogo({ Key? key }) : super(key: key);
@@ -25,7 +26,7 @@ const IconLogo({ Key? key }) : super(key: key);
               ),
             ),
             Text(
-              'Support Sphere',
+              AppStrings.appName,
               style: TextStyle(
                 fontSize: 22.0,
                 fontWeight: FontWeight.w900,


### PR DESCRIPTION
This pull request includes updates to the `src/support_sphere` directory to change the app name and improve code maintainability by centralizing string constants.

Changes to app name and string constants:

* [`src/support_sphere/lib/constants/string_catalog.dart`](diffhunk://#diff-9663c9e5e9c15a602ae60e64b7178cbfd727abbac179b5aaefcab70a956373fdL3-R3): Updated the `appName` constant from 'Support Sphere' to 'Resilience - Laurelhurst'.
* [`src/support_sphere/lib/presentation/components/icon_logo.dart`](diffhunk://#diff-586a5ce69f3bf81acbd99a6e8282ff50e6c35a994e04940cfa9ec8dd69e9857dR4): Imported `string_catalog.dart` to use the centralized string constants.
* [`src/support_sphere/lib/presentation/components/icon_logo.dart`](diffhunk://#diff-586a5ce69f3bf81acbd99a6e8282ff50e6c35a994e04940cfa9ec8dd69e9857dL28-R29): Replaced the hardcoded app name 'Support Sphere' with `AppStrings.appName` to use the updated app name.