### PR TITLE
docs: Remove fastapi instruction, not implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,16 +56,7 @@ To run this app locally, follow these steps:
    pixi run setup-db-data-via-k8s-job
    ```
    
-4. Run the API server locally by running the following command in a new terminal session.  
-   Note: the argument `fast-api-server-dev` in the command below runs the server in editable mode, where each change in 
-   the source file triggers the restart of the fastapi local server.  
-   For production: replace `fast-api-server-dev` with `fast-api-server-run`.
-
-   ```console
-   pixi run fast-api-server-dev
-   ```  
-   
-   At this point your backend is now ready to go! Now off to frontend
+At this point your backend is now ready to go! Now off to frontend
 
 
 ### Frontend

--- a/docs/backend/index.md
+++ b/docs/backend/index.md
@@ -33,12 +33,6 @@ To run this app locally, follow these steps:
     ```console
     pixi run -e backend setup-db-data-via-k8s-job
     ```
-5. Optional: Run the API server locally by running the following command in a new terminal session.  
-    Note: the argument `fast-api-server-dev` in the command below runs the server in editable mode, where each change in  the source file triggers the restart of the fastapi local server.  
-    For production: replace `fast-api-server-dev` with `fast-api-server-run`.
-    ```console
-    pixi run -e backend fast-api-server-dev
-    ```
 
 ## Database diagram
 


### PR DESCRIPTION
This pull request includes a change to the `README.md` file to simplify the instructions for running the API server locally.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-L67): Removed detailed instructions for running the API server locally, including the note about running the server in editable mode and the command for production.

This was an artifact, from exploratory phase of the project. The backbone for fast api service is there, but we never actually implemented it fully.

## Related Issues

Closes #226