### PR TITLE
fix: Fix the WKBElement pydantic validation

### DIFF
--- a/src/support_sphere_py/src/support_sphere/models/public/point_of_interest.py
+++ b/src/support_sphere_py/src/support_sphere/models/public/point_of_interest.py
@@ -1,7 +1,7 @@
 import uuid
 from support_sphere.models.base import BasePublicSchemaModel
 from sqlmodel import Field
-from geoalchemy2 import Geometry
+from geoalchemy2 import WKBElement, Geometry
 
 
 class PointOfInterest(BasePublicSchemaModel, table=True):
@@ -25,4 +25,4 @@ class PointOfInterest(BasePublicSchemaModel, table=True):
     id: uuid.UUID = Field(default_factory=uuid.uuid4, primary_key=True)
     name: str | None = Field(nullable=False)
     address: str | None = Field(nullable=False)
-    geom: Geometry|None = Field(sa_type=Geometry(geometry_type="POLYGON"), nullable=True)
+    geom: WKBElement|None = Field(sa_type=Geometry(geometry_type="POLYGON"), nullable=True)


### PR DESCRIPTION
Try changing the pydantic type for proper validation. This PR is a fix to resolve the following as brought to our attention by @philion 

Essentially, I've been working on loading the DB (postgres, in supabase) with Geometry points (see [https://github.com/UW-THINKlab/resilience/blob/main/src/support_sphere_py/src/support_sphere/models/public/point_of_interest.py](https://urldefense.com/v3/__https://github.com/UW-THINKlab/resilience/blob/main/src/support_sphere_py/src/support_sphere/models/public/point_of_interest.py__;!!K-Hz7m0Vt54!nKuqzN8PDBeQ7FQbbBxYWRXlohH6wEF-yfkc04LpJAGVqOlEszQyArsNbbRaRJKGg_T7RKZNeaHohCHgmA$), for example), but I am getting errors haven't been able to fix.

Specifically, when creating a Point of Interest, and trying to load it into the DB using the object created by the shapely tools ([https://pypi.org/project/shapely/](https://urldefense.com/v3/__https://pypi.org/project/shapely/__;!!K-Hz7m0Vt54!nKuqzN8PDBeQ7FQbbBxYWRXlohH6wEF-yfkc04LpJAGVqOlEszQyArsNbbRaRJKGg_T7RKZNeaG7TZsiqA$)) from simple geometry objects.

I run into problem with pydantic, build into sqlmodel:

```
ValidationError: 1 validation error for PointOfInterest
geom
  Input should be an instance of Geometry [type=is_instance_of, input_value=<WKBElement at 0x1092afe8...9d447405a8ae7c703925ec0>, input_type=WKBElement]
    For further information visit [https://errors.pydantic.dev/2.11/v/is_instance_of](https://urldefense.com/v3/__https://errors.pydantic.dev/2.11/v/is_instance_of__;!!K-Hz7m0Vt54!nKuqzN8PDBeQ7FQbbBxYWRXlohH6wEF-yfkc04LpJAGVqOlEszQyArsNbbRaRJKGg_T7RKZNeaGF4vHA1g$)
```
I have been unable to figure out how to convert a WKBElement into a Geometry object to satisfy pydantic.