### PR TITLE
Fix broken 'Edit this repo' links by using main branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,6 +4,7 @@ site_name: Resilience App Documentation
 # Repository
 repo_name: UW-THINKlab/resilience
 repo_url: https://github.com/UW-THINKlab/resilience
+edit_uri: edit/main/docs/
 
 # Configuration
 theme:


### PR DESCRIPTION
## Summary\n- add explicit `edit_uri` in `mkdocs.yml`\n- point edit links to `edit/main/docs/` instead of MkDocs default branch assumptions\n\nFixes #248