### PR TITLE
fixing map display and logging regression

### DIFF
--- a/src/support_sphere/lib/data/repositories/home.dart
+++ b/src/support_sphere/lib/data/repositories/home.dart
@@ -2,13 +2,13 @@ import 'package:geodesy/geodesy.dart';
 import 'package:logging/logging.dart' show Logger;
 import 'package:support_sphere/data/models/clusters.dart';
 import 'package:support_sphere/data/models/captain_marker.dart';
-import 'package:support_sphere/data/repositories/cluster.dart' show ClusterRepository;
+import 'package:support_sphere/data/repositories/cluster.dart'
+    show ClusterRepository;
 import 'package:support_sphere/data/services/cluster_service.dart';
 import 'package:support_sphere/data/services/poi_service.dart';
 import 'package:support_sphere/data/models/point_of_interest.dart';
 
 final log = Logger('HomeRepository');
-
 
 class HomeRepository {
   final ClusterService _clusterService = ClusterService();
@@ -39,19 +39,27 @@ class HomeRepository {
     final pointsOfInterest = await _poiService.getPointsOfInterest();
 
     return (
-      captainMarkers: captains
-          ?.map((captain) => CaptainMarker(
-                id: captain['id'],
-                familyName: captain['family_name'],
-                givenName: captain['given_name'],
-                householdGeom: captain['people_groups']['households']['geom'] != null
-                    ? PolygonCentroid.findPolygonCentroid(
-                        captain['people_groups']['households']['geom']['coordinates'][0]
-                            .map<LatLng>((coord) => LatLng(coord[1], coord[0]))
-                            .toList())
-                    : null,
-              ))
-          .toList(),
+      captainMarkers: captains?.map((captain) {
+        LatLng? householdGeom;
+        final geom = captain['people_groups']['households']['geom'];
+        switch (geom['type']) {
+          case "Point":
+            final latlng =
+                LatLng(geom['coordinates'][1], geom['coordinates'][0]);
+            householdGeom = PolygonCentroid.findPolygonCentroid([latlng]);
+            break;
+          default:
+            log.warning(
+              'Geom type of type ${geom['type'].runtimeType} is not handled',
+            );
+        }
+        return CaptainMarker(
+          id: captain['id'],
+          familyName: captain['family_name'],
+          givenName: captain['given_name'],
+          householdGeom: householdGeom,
+        );
+      }).toList(),
       cluster: cluster,
       pointsOfInterest: pointsOfInterest,
     );

--- a/src/support_sphere/lib/main.dart
+++ b/src/support_sphere/lib/main.dart
@@ -16,7 +16,7 @@ void initializeLogging(Level level) {
   Logger.root.level = level;
   Logger.root.onRecord.listen((record) {
     // ignore: avoid_print - This is a standard logger
-    log.fine('${record.time} ${record.level}: ${record.message}');
+    debugPrint('${record.time} ${record.level}: ${record.message}');
   });
 }
 


### PR DESCRIPTION
## summary
First, fixing the logs that I broke before

Second, fixing how the LatLng centroid is calculated from the db response, couple of questions on that though:
1. I couldn't find a place in the history of the package when the point was being parsed differently, pretty much since it was added in [this commit](389cc38583e06574ba9275af282b4e9dc5375f4b) so the only possible explaination is change in how we return it from the db (which is possible, just couldn't figure out how to verify myself)
2. the `findPolygonCentroid` works for polygons, it apparently works okay if we pass a list of a single point but I'm wondering if we ever need that? I checked the db and all geometry types were point, didn't want to delete it before confirmation though.

## testing
- verified logs are working again
- used my eyes hehe
<img width="1186" height="759" alt="Screenshot 2026-06-08 at 5 49 51 PM" src="https://github.com/user-attachments/assets/e5070269-043e-4f37-a08d-27f8393669f0" />