### PR TITLE
#321 use database to track read receipts

### DIFF
--- a/src/support_sphere/lib/data/models/chat_group.dart
+++ b/src/support_sphere/lib/data/models/chat_group.dart
@@ -8,6 +8,7 @@ class ChatGroup extends Equatable {
   final String? description;
   final List<String> members;
   final GROUP_CHAT_TYPE type;
+  final int unreadCount;
 
   const ChatGroup({
     required this.id,
@@ -16,6 +17,7 @@ class ChatGroup extends Equatable {
     this.description,
     required this.members,
     required this.type,
+    required this.unreadCount,
   });
 
   factory ChatGroup.from(
@@ -25,6 +27,7 @@ class ChatGroup extends Equatable {
     String? description,
     String lastMessage = '',
     GROUP_CHAT_TYPE type = GROUP_CHAT_TYPE.chat,
+    int unreadCount = 0,
   }) {
     return ChatGroup(
       id: id,
@@ -33,6 +36,7 @@ class ChatGroup extends Equatable {
       description: description,
       members: members,
       type: type,
+      unreadCount: unreadCount,
     );
   }
 

--- a/src/support_sphere/lib/data/models/generated_classes.dart
+++ b/src/support_sphere/lib/data/models/generated_classes.dart
@@ -46,6 +46,7 @@ extension SupadartClient on SupabaseClient {
       from('resource_subtype_tags');
   SupabaseQueryBuilder get user_captain_clusters =>
       from('user_captain_clusters');
+  SupabaseQueryBuilder get message_reads => from('message_reads');
   SupabaseQueryBuilder get resources => from('resources');
   SupabaseQueryBuilder get groups => from('groups');
   SupabaseQueryBuilder get resource_reservations =>
@@ -1129,6 +1130,112 @@ class UserCaptainClusters implements SupadartClass<UserCaptainClusters> {
       id: id == _unset ? this.id : id as String,
       clusterId: clusterId == _unset ? this.clusterId : clusterId as String,
       userRoleId: userRoleId == _unset ? this.userRoleId : userRoleId as String,
+    );
+  }
+}
+
+class MessageReads implements SupadartClass<MessageReads> {
+  final String messageId;
+  final String profileId;
+  final DateTime readAt;
+
+  const MessageReads({
+    required this.messageId,
+    required this.profileId,
+    required this.readAt,
+  });
+
+  static String get table_name => 'message_reads';
+  static String get c_messageId => 'message_id';
+  static String get c_profileId => 'profile_id';
+  static String get c_readAt => 'read_at';
+
+  static List<MessageReads> converter(List<Map<String, dynamic>> data) {
+    return data.map(MessageReads.fromJson).toList();
+  }
+
+  static MessageReads converterSingle(Map<String, dynamic> data) {
+    return MessageReads.fromJson(data);
+  }
+
+  static Map<String, dynamic> _generateMap({
+    String? messageId,
+    String? profileId,
+    DateTime? readAt,
+  }) {
+    return {
+      if (messageId != null) 'message_id': messageId,
+      if (profileId != null) 'profile_id': profileId,
+      if (readAt != null) 'read_at': readAt.toIso8601String(),
+    };
+  }
+
+  static Map<String, dynamic> insert({
+    String? messageId,
+    String? profileId,
+    DateTime? readAt,
+  }) {
+    return _generateMap(
+      messageId: messageId,
+      profileId: profileId,
+      readAt: readAt,
+    );
+  }
+
+  static Map<String, dynamic> update({
+    String? messageId,
+    String? profileId,
+    DateTime? readAt,
+  }) {
+    return _generateMap(
+      messageId: messageId,
+      profileId: profileId,
+      readAt: readAt,
+    );
+  }
+
+  factory MessageReads.fromJson(Map<String, dynamic> jsonn) {
+    return MessageReads(
+      messageId:
+          jsonn['message_id'] != null ? jsonn['message_id'].toString() : '',
+      profileId:
+          jsonn['profile_id'] != null ? jsonn['profile_id'].toString() : '',
+      readAt: jsonn['read_at'] != null
+          ? DateTime.parse(jsonn['read_at'].toString())
+          : DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  static Object New({
+    String? messageId,
+    String? profileId,
+    DateTime? readAt,
+  }) {
+    return {
+      if (messageId != null) 'message_id': messageId,
+      if (profileId != null) 'profile_id': profileId,
+      if (readAt != null) 'read_at': readAt,
+    };
+  }
+
+  Map<String, dynamic> toJson() {
+    return _generateMap(
+      messageId: messageId,
+      profileId: profileId,
+      readAt: readAt,
+    );
+  }
+
+  static const _unset = Object();
+  MessageReads copyWith({
+    Object? messageId = _unset,
+    Object? profileId = _unset,
+    Object? readAt = _unset,
+  }) {
+    return MessageReads(
+      messageId: messageId == _unset ? this.messageId : messageId as String,
+      profileId: profileId == _unset ? this.profileId : profileId as String,
+      readAt: readAt == _unset ? this.readAt : readAt as DateTime,
     );
   }
 }

--- a/src/support_sphere/lib/data/repositories/chat_repository.dart
+++ b/src/support_sphere/lib/data/repositories/chat_repository.dart
@@ -39,7 +39,7 @@ class ChatRepository {
 
     return response
         .where((item) => isUserIdInList(userId, item.$2))
-        .map(responseToChatGroup)
+        .map((res) => responseToChatGroup(res, userId))
         .wait;
   }
 
@@ -49,11 +49,13 @@ class ChatRepository {
     return list.any((p) => p.userProfileId == uid);
   }
 
-  Future<ChatGroup> responseToChatGroup((Groups, List<People>) response) async {
+  Future<ChatGroup> responseToChatGroup(
+      (Groups, List<People>) response, String uid) async {
     final MessagesRepository messageRepo = MessagesRepository();
     final group = response.$1;
     final members = response.$2;
     final lastMessage = await messageRepo.lastUnreadMessage(group.id);
+    final unreadCount = await messageRepo.unreadCount(group.id, uid);
     return ChatGroup.from(
       group.id,
       group.name,
@@ -61,6 +63,7 @@ class ChatRepository {
       type: group.type,
       lastMessage: lastMessage,
       members: members.map((e) => e.givenName ?? '').toList(),
+      unreadCount: unreadCount,
     );
   }
 

--- a/src/support_sphere/lib/data/repositories/message.dart
+++ b/src/support_sphere/lib/data/repositories/message.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart' show Logger;
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:support_sphere/data/models/generated_classes.dart';
 import 'package:support_sphere/data/models/messages.dart';
 import 'package:support_sphere/utils/supabase.dart';
 import 'package:uuid/v4.dart' show UuidV4;
@@ -24,13 +25,24 @@ class MessagesRepository {
         .map((maps) => maps.map((map) => Message.fromJson(json: map)).toList());
   }
 
-  Future<int> unreadCount(String groupId, String time) async {
-    final List<dynamic> data = await supabase
-        .from('messages')
-        .select('id')
-        .eq('to_id', groupId)
-        .gte('sent_on', time);
-    return data.length;
+  Future<int> unreadCount(String groupId, String userId) {
+    return supabase.rpc(
+      'get_unread_count',
+      params: {'p_profile_id': userId, 'p_group_id': groupId},
+    );
+  }
+
+  Future<void> markMessagesRead(String groupId, String userId) async {
+    final msgs = await supabase.messages
+        .select()
+        .eq(Messages.c_toId, groupId)
+        .withConverter(Messages.converter);
+    for (Messages msg in msgs) {
+      await supabase.message_reads.upsert(MessageReads.insert(
+        messageId: msg.id,
+        profileId: userId,
+      ));
+    }
   }
 
   Future<String> lastUnreadMessage(String groupId) async {

--- a/src/support_sphere/lib/presentation/pages/main_app/messages/inbox_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/messages/inbox_page.dart
@@ -115,6 +115,12 @@ class InboxView extends StatelessWidget {
                         ),
                       ],
                     ),
+                    trailing: group.unreadCount > 0
+                        ? Badge(
+                            label: Text(group.unreadCount.toString()),
+                            child: const Icon(Icons.circle),
+                          )
+                        : null,
                     onTap: () => _navigateToChat(context, group),
                   ),
                 ),
@@ -132,19 +138,17 @@ class InboxView extends StatelessWidget {
 
   void _navigateToChat(BuildContext context, ChatGroup group) async {
     log.fine('🧭 Navigating to: ${group.id}'); // ✅ Verify source
-    final prefs = await SharedPreferences.getInstance();
-    prefs.setString(group.id, DateTime.now().toString());
-    if (context.mounted) {
-      Navigator.push(
-        context,
-        MaterialPageRoute(
-          builder: (context) => MessagesPage(
-            groupId: group.id,
-            groupName: group.name,
-          ),
+    await Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => MessagesPage(
+          groupId: group.id,
+          groupName: group.name,
         ),
-      );
-    }
+      ),
+    );
+    if (!context.mounted) return;
+    await context.read<InboxCubit>().fetchGroups();
   }
 
   Future<void> _openCreateGroupSheet(BuildContext context) async {
@@ -167,9 +171,6 @@ class InboxView extends StatelessWidget {
     if (result != null && context.mounted) {
       await context.read<InboxCubit>().fetchGroups();
       final (groupId, groupName) = result;
-      final prefs = await SharedPreferences.getInstance();
-      prefs.setString(groupId, DateTime.now().toString());
-
       if (context.mounted) {
         Navigator.push(
           context,

--- a/src/support_sphere/lib/presentation/pages/main_app/messages/messages_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/messages/messages_page.dart
@@ -59,6 +59,8 @@ class MessagesState extends State<MessagesPage> {
     log.fine("MY GROUP ID: $widget.groupId");
     final allUsers = await userRepo.getAllMembers();
     profileCache.addAll(allUsers);
+    // mark all messages read
+    await messageRepo.markMessagesRead(widget.groupId, myUserId);
     if (!mounted) return;
     setState(() => {});
   }


### PR DESCRIPTION
# Modifications to database

## messages_read table
```sql
create table message_reads (
  message_id uuid not null,
  profile_id uuid not null,
  read_at timestamp not null default current_timestamp,
  primary key (message_id, profile_id),
  foreign key (message_id) REFERENCES messages(id),
  foreign key (profile_id) REFERENCES user_profiles(id)
);
```
## unread count function
```sql
create or replace function get_unread_count(p_profile_id uuid, p_group_id uuid) returns integer language sql as $$
select count(*) as unread_count
from messages m
left join message_reads mr
  on mr.message_id = m.id
 and mr.profile_id = p_profile_id
where m.to_id = p_group_id
  and mr.message_id is null;
$$;
```

# result
read count works appropriately now