### PR TITLE
bugfix 348- person selector

### DIFF
--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -189,10 +189,10 @@ class AppModes {
 }
 
 class AppRoles {
-  static const String user = 'USER';
-  static const String subcommunityAgent = 'SUBCOM_AGENT';
-  static const String communityAdmin = 'COM_ADMIN';
-  static const String admin = 'ADMIN';
+  static const String user = 'user';
+  static const String subcommunityAgent = 'subcom_agent';
+  static const String communityAdmin = 'com_admin';
+  static const String admin = 'admin';
 }
 
 class NavRouteLabels {

--- a/src/support_sphere/lib/constants/string_catalog.dart
+++ b/src/support_sphere/lib/constants/string_catalog.dart
@@ -121,7 +121,7 @@ class ResourceStrings {
   static const String selectResourceType = 'Select a resource type';
   static const String noResourcesFound = 'No resources found';
   static const String allResources = 'All Resources';
-  static const String addResource = 'Add New Resource or Skill';
+  static const String addResource = 'New Resource';
   static const String manageResources = 'Manage Resources';
   static const String resourcesInventory = 'Resources Inventory';
   static const String noUserResources = 'You have not added any resources yet';
@@ -204,7 +204,7 @@ class NavRouteLabels {
   static const String manageResources = 'Manage Resources';
   static const String manageChecklists = 'Manage Checklists';
   static const String adminCluster = 'Cluster Admin';
-  static const String adminNeighborhood = 'Neighbothood Admin';
+  static const String adminNeighborhood = 'Neighborhood Admin';
 }
 
 class ClusterAdminStrings {
@@ -219,14 +219,15 @@ class ClusterAdminStrings {
 }
 
 class NeighborhoodStrings {
-  static const String addCluster = 'Add cluster';
+  static const String addCluster = 'New cluster';
   static const String selectFilter = 'Filter clusters';
   static const String clusterFilterAll = "All clusters";
   static const String clusterFilterNeedCaptain = "Needs captain";
   static const String clusterFilterParticipate = "Low participation";
   static const String searchClusters = "Search clusters";
   static const String noClustersFound = 'No Cluster found';
+  static const String captainNeeded = 'Captain needed';
 
   static const String manageNeighborhood =
-      "Manage Laurenhurst"; // FIXME - neighborhood name
+      "Manage Laurelhurst"; // FIXME - neighborhood name
 }

--- a/src/support_sphere/lib/data/models/generated_classes.dart
+++ b/src/support_sphere/lib/data/models/generated_classes.dart
@@ -40,6 +40,8 @@ extension SupadartClient on SupabaseClient {
   SupabaseQueryBuilder get point_of_interests => from('point_of_interests');
   SupabaseQueryBuilder get user_resources => from('user_resources');
   SupabaseQueryBuilder get resource_tags => from('resource_tags');
+  SupabaseQueryBuilder get cluster_captains_view =>
+      from('cluster_captains_view');
   SupabaseQueryBuilder get checklists => from('checklists');
   SupabaseQueryBuilder get resource_types => from('resource_types');
   SupabaseQueryBuilder get resource_subtype_tags =>
@@ -669,6 +671,181 @@ class ResourceTags implements SupadartClass<ResourceTags> {
       resourceSubtypeTagId: resourceSubtypeTagId == _unset
           ? this.resourceSubtypeTagId
           : resourceSubtypeTagId as String?,
+    );
+  }
+}
+
+class ClusterCaptainsView implements SupadartClass<ClusterCaptainsView> {
+  final String? clusterId;
+  final String? clusterName;
+  final APP_ROLES? userRole;
+  final String? userProfileId;
+  final String? givenName;
+  final String? familyName;
+  final String? nickname;
+
+  const ClusterCaptainsView({
+    this.clusterId,
+    this.clusterName,
+    this.userRole,
+    this.userProfileId,
+    this.givenName,
+    this.familyName,
+    this.nickname,
+  });
+
+  static String get table_name => 'cluster_captains_view';
+  static String get c_clusterId => 'cluster_id';
+  static String get c_clusterName => 'cluster_name';
+  static String get c_userRole => 'user_role';
+  static String get c_userProfileId => 'user_profile_id';
+  static String get c_givenName => 'given_name';
+  static String get c_familyName => 'family_name';
+  static String get c_nickname => 'nickname';
+
+  static List<ClusterCaptainsView> converter(List<Map<String, dynamic>> data) {
+    return data.map(ClusterCaptainsView.fromJson).toList();
+  }
+
+  static ClusterCaptainsView converterSingle(Map<String, dynamic> data) {
+    return ClusterCaptainsView.fromJson(data);
+  }
+
+  static Map<String, dynamic> _generateMap({
+    String? clusterId,
+    String? clusterName,
+    APP_ROLES? userRole,
+    String? userProfileId,
+    String? givenName,
+    String? familyName,
+    String? nickname,
+  }) {
+    return {
+      if (clusterId != null) 'cluster_id': clusterId,
+      if (clusterName != null) 'cluster_name': clusterName,
+      if (userRole != null) 'user_role': userRole.toString().split('.').last,
+      if (userProfileId != null) 'user_profile_id': userProfileId,
+      if (givenName != null) 'given_name': givenName,
+      if (familyName != null) 'family_name': familyName,
+      if (nickname != null) 'nickname': nickname,
+    };
+  }
+
+  static Map<String, dynamic> insert({
+    String? clusterId,
+    String? clusterName,
+    APP_ROLES? userRole,
+    String? userProfileId,
+    String? givenName,
+    String? familyName,
+    String? nickname,
+  }) {
+    return _generateMap(
+      clusterId: clusterId,
+      clusterName: clusterName,
+      userRole: userRole,
+      userProfileId: userProfileId,
+      givenName: givenName,
+      familyName: familyName,
+      nickname: nickname,
+    );
+  }
+
+  static Map<String, dynamic> update({
+    String? clusterId,
+    String? clusterName,
+    APP_ROLES? userRole,
+    String? userProfileId,
+    String? givenName,
+    String? familyName,
+    String? nickname,
+  }) {
+    return _generateMap(
+      clusterId: clusterId,
+      clusterName: clusterName,
+      userRole: userRole,
+      userProfileId: userProfileId,
+      givenName: givenName,
+      familyName: familyName,
+      nickname: nickname,
+    );
+  }
+
+  factory ClusterCaptainsView.fromJson(Map<String, dynamic> jsonn) {
+    return ClusterCaptainsView(
+      clusterId:
+          jsonn['cluster_id'] != null ? jsonn['cluster_id'].toString() : null,
+      clusterName: jsonn['cluster_name'] != null
+          ? jsonn['cluster_name'].toString()
+          : null,
+      userRole: jsonn['user_role'] != null
+          ? APP_ROLES.values.byName(jsonn['user_role'].toString())
+          : APP_ROLES.values.first,
+      userProfileId: jsonn['user_profile_id'] != null
+          ? jsonn['user_profile_id'].toString()
+          : null,
+      givenName:
+          jsonn['given_name'] != null ? jsonn['given_name'].toString() : null,
+      familyName:
+          jsonn['family_name'] != null ? jsonn['family_name'].toString() : null,
+      nickname: jsonn['nickname'] != null ? jsonn['nickname'].toString() : null,
+    );
+  }
+
+  static Object New({
+    String? clusterId,
+    String? clusterName,
+    APP_ROLES? userRole,
+    String? userProfileId,
+    String? givenName,
+    String? familyName,
+    String? nickname,
+  }) {
+    return {
+      if (clusterId != null) 'cluster_id': clusterId,
+      if (clusterName != null) 'cluster_name': clusterName,
+      if (userRole != null) 'user_role': userRole,
+      if (userProfileId != null) 'user_profile_id': userProfileId,
+      if (givenName != null) 'given_name': givenName,
+      if (familyName != null) 'family_name': familyName,
+      if (nickname != null) 'nickname': nickname,
+    };
+  }
+
+  Map<String, dynamic> toJson() {
+    return _generateMap(
+      clusterId: clusterId,
+      clusterName: clusterName,
+      userRole: userRole,
+      userProfileId: userProfileId,
+      givenName: givenName,
+      familyName: familyName,
+      nickname: nickname,
+    );
+  }
+
+  static const _unset = Object();
+  ClusterCaptainsView copyWith({
+    Object? clusterId = _unset,
+    Object? clusterName = _unset,
+    Object? userRole = _unset,
+    Object? userProfileId = _unset,
+    Object? givenName = _unset,
+    Object? familyName = _unset,
+    Object? nickname = _unset,
+  }) {
+    return ClusterCaptainsView(
+      clusterId: clusterId == _unset ? this.clusterId : clusterId as String?,
+      clusterName:
+          clusterName == _unset ? this.clusterName : clusterName as String?,
+      userRole: userRole == _unset ? this.userRole : userRole as APP_ROLES?,
+      userProfileId: userProfileId == _unset
+          ? this.userProfileId
+          : userProfileId as String?,
+      givenName: givenName == _unset ? this.givenName : givenName as String?,
+      familyName:
+          familyName == _unset ? this.familyName : familyName as String?,
+      nickname: nickname == _unset ? this.nickname : nickname as String?,
     );
   }
 }

--- a/src/support_sphere/lib/data/models/generated_classes.dart
+++ b/src/support_sphere/lib/data/models/generated_classes.dart
@@ -856,8 +856,8 @@ class Checklists implements SupadartClass<Checklists> {
   final String? description;
   final String? notes;
   final DateTime updatedAt;
-  final PRIORITY priority;
   final String? frequencyId;
+  final PRIORITY priority;
 
   const Checklists({
     required this.id,
@@ -865,8 +865,8 @@ class Checklists implements SupadartClass<Checklists> {
     this.description,
     this.notes,
     required this.updatedAt,
-    required this.priority,
     this.frequencyId,
+    required this.priority,
   });
 
   static String get table_name => 'checklists';
@@ -875,8 +875,8 @@ class Checklists implements SupadartClass<Checklists> {
   static String get c_description => 'description';
   static String get c_notes => 'notes';
   static String get c_updatedAt => 'updated_at';
-  static String get c_priority => 'priority';
   static String get c_frequencyId => 'frequency_id';
+  static String get c_priority => 'priority';
 
   static List<Checklists> converter(List<Map<String, dynamic>> data) {
     return data.map(Checklists.fromJson).toList();
@@ -892,8 +892,8 @@ class Checklists implements SupadartClass<Checklists> {
     String? description,
     String? notes,
     DateTime? updatedAt,
-    PRIORITY? priority,
     String? frequencyId,
+    PRIORITY? priority,
   }) {
     return {
       if (id != null) 'id': id,
@@ -901,8 +901,8 @@ class Checklists implements SupadartClass<Checklists> {
       if (description != null) 'description': description,
       if (notes != null) 'notes': notes,
       if (updatedAt != null) 'updated_at': updatedAt.toIso8601String(),
-      if (priority != null) 'priority': priority.toString().split('.').last,
       if (frequencyId != null) 'frequency_id': frequencyId,
+      if (priority != null) 'priority': priority.toString().split('.').last,
     };
   }
 
@@ -912,8 +912,8 @@ class Checklists implements SupadartClass<Checklists> {
     String? description,
     String? notes,
     required DateTime updatedAt,
-    required PRIORITY priority,
     String? frequencyId,
+    PRIORITY? priority,
   }) {
     return _generateMap(
       id: id,
@@ -921,8 +921,8 @@ class Checklists implements SupadartClass<Checklists> {
       description: description,
       notes: notes,
       updatedAt: updatedAt,
-      priority: priority,
       frequencyId: frequencyId,
+      priority: priority,
     );
   }
 
@@ -932,8 +932,8 @@ class Checklists implements SupadartClass<Checklists> {
     String? description,
     String? notes,
     DateTime? updatedAt,
-    PRIORITY? priority,
     String? frequencyId,
+    PRIORITY? priority,
   }) {
     return _generateMap(
       id: id,
@@ -941,8 +941,8 @@ class Checklists implements SupadartClass<Checklists> {
       description: description,
       notes: notes,
       updatedAt: updatedAt,
-      priority: priority,
       frequencyId: frequencyId,
+      priority: priority,
     );
   }
 
@@ -956,12 +956,12 @@ class Checklists implements SupadartClass<Checklists> {
       updatedAt: jsonn['updated_at'] != null
           ? DateTime.parse(jsonn['updated_at'].toString())
           : DateTime.fromMillisecondsSinceEpoch(0),
-      priority: jsonn['priority'] != null
-          ? PRIORITY.values.byName(jsonn['priority'].toString())
-          : PRIORITY.values.first,
       frequencyId: jsonn['frequency_id'] != null
           ? jsonn['frequency_id'].toString()
           : null,
+      priority: jsonn['priority'] != null
+          ? PRIORITY.values.byName(jsonn['priority'].toString())
+          : PRIORITY.values.first,
     );
   }
 
@@ -971,8 +971,8 @@ class Checklists implements SupadartClass<Checklists> {
     String? description,
     String? notes,
     DateTime? updatedAt,
-    PRIORITY? priority,
     String? frequencyId,
+    PRIORITY? priority,
   }) {
     return {
       if (id != null) 'id': id,
@@ -980,8 +980,8 @@ class Checklists implements SupadartClass<Checklists> {
       if (description != null) 'description': description,
       if (notes != null) 'notes': notes,
       if (updatedAt != null) 'updated_at': updatedAt,
-      if (priority != null) 'priority': priority,
       if (frequencyId != null) 'frequency_id': frequencyId,
+      if (priority != null) 'priority': priority,
     };
   }
 
@@ -992,8 +992,8 @@ class Checklists implements SupadartClass<Checklists> {
       description: description,
       notes: notes,
       updatedAt: updatedAt,
-      priority: priority,
       frequencyId: frequencyId,
+      priority: priority,
     );
   }
 
@@ -1004,8 +1004,8 @@ class Checklists implements SupadartClass<Checklists> {
     Object? description = _unset,
     Object? notes = _unset,
     Object? updatedAt = _unset,
-    Object? priority = _unset,
     Object? frequencyId = _unset,
+    Object? priority = _unset,
   }) {
     return Checklists(
       id: id == _unset ? this.id : id as String,
@@ -1014,9 +1014,9 @@ class Checklists implements SupadartClass<Checklists> {
           description == _unset ? this.description : description as String?,
       notes: notes == _unset ? this.notes : notes as String?,
       updatedAt: updatedAt == _unset ? this.updatedAt : updatedAt as DateTime,
-      priority: priority == _unset ? this.priority : priority as PRIORITY,
       frequencyId:
           frequencyId == _unset ? this.frequencyId : frequencyId as String?,
+      priority: priority == _unset ? this.priority : priority as PRIORITY,
     );
   }
 }
@@ -2396,8 +2396,8 @@ class RolePermissions implements SupadartClass<RolePermissions> {
 
   static Map<String, dynamic> insert({
     String? id,
-    required APP_ROLES role,
-    required APP_PERMISSIONS permission,
+    APP_ROLES? role,
+    APP_PERMISSIONS? permission,
   }) {
     return _generateMap(
       id: id,
@@ -2779,7 +2779,7 @@ class UserRoles implements SupadartClass<UserRoles> {
   static Map<String, dynamic> insert({
     String? id,
     required String userProfileId,
-    required APP_ROLES role,
+    APP_ROLES? role,
   }) {
     return _generateMap(
       id: id,

--- a/src/support_sphere/lib/data/repositories/chat_repository.dart
+++ b/src/support_sphere/lib/data/repositories/chat_repository.dart
@@ -62,7 +62,7 @@ class ChatRepository {
       description: group.description,
       type: group.type,
       lastMessage: lastMessage,
-      members: members.map((e) => e.givenName ?? '').toList(),
+      members: members.map((e) => e.userProfileId ?? '').toList(),
       unreadCount: unreadCount,
     );
   }

--- a/src/support_sphere/lib/data/repositories/cluster.dart
+++ b/src/support_sphere/lib/data/repositories/cluster.dart
@@ -1,6 +1,7 @@
 import 'package:geodesy/geodesy.dart';
 import 'package:logging/logging.dart' show Logger;
 import 'package:support_sphere/data/models/clusters.dart';
+import 'package:support_sphere/data/models/generated_classes.dart';
 import 'package:support_sphere/data/models/households.dart';
 import 'package:support_sphere/data/models/person.dart';
 import 'package:support_sphere/data/services/cluster_service.dart';
@@ -87,6 +88,13 @@ class ClusterRepository {
 
   Future<void> deleteCluster(String clusterId) async {
     return _clusterService.deleteCluster(clusterId);
+  }
+
+  Future<List<ClusterCaptainsView>> getCaptainsViewByClusterId(
+      String clusterId) async {
+    final data = await _clusterService.getCaptainsViewByClusterId(clusterId);
+    if (data == null) return [];
+    return ClusterCaptainsView.converter(data);
   }
 
   Future<void> addClusterCaptain(String clusterId, Person? person) async {

--- a/src/support_sphere/lib/data/repositories/cluster.dart
+++ b/src/support_sphere/lib/data/repositories/cluster.dart
@@ -1,7 +1,8 @@
 import 'package:geodesy/geodesy.dart';
 import 'package:logging/logging.dart' show Logger;
 import 'package:support_sphere/data/models/clusters.dart';
-import 'package:support_sphere/data/models/generated_classes.dart';
+import 'package:support_sphere/data/models/generated_classes.dart'
+    show ClusterCaptainsView, APP_ROLES;
 import 'package:support_sphere/data/models/households.dart';
 import 'package:support_sphere/data/models/person.dart';
 import 'package:support_sphere/data/services/cluster_service.dart';
@@ -79,11 +80,11 @@ class ClusterRepository {
     // checking captains
     if (clusterUpdate.containsKey('captains')) {
       final captains = clusterUpdate.remove('captains');
-      updateCaptains(clusterId, captains);
+      await updateCaptains(clusterId, captains);
     }
     // TODO any geometry will also need special case
 
-    _clusterService.upsertCluster(clusterUpdate);
+    await _clusterService.upsertCluster(clusterUpdate);
   }
 
   Future<void> deleteCluster(String clusterId) async {
@@ -97,53 +98,47 @@ class ClusterRepository {
     return ClusterCaptainsView.converter(data);
   }
 
-  Future<void> addClusterCaptain(String clusterId, Person? person) async {
-    log.fine("IMPLEMENT adding ${person?.name()} as captain for cluster id: $clusterId");
-
-    // FIXME
-    // check if they're already a captain: role
-    // add the new captain role in user_role, get id
-    // use that ID=user_role_id to add new user_cluser_captain, with cluster_id and new UUID
-  }
-
-  Future<void> removeClusterCaptain(String clusterId, Person? person) async {
-    log.fine("IMPLEMENT removing ${person?.name()} as captain of cluster id: $clusterId");
-
-    // check if they're already a captain: role
-    // add the new captain role in user_role, get id
-    // use that ID=user_role_id to add new user_cluser_captain, with cluster_id and new UUID
-    // FIXME -
-    // delete user_role, or just user_captain_clusters row?
-    // BOTH!!!!
-    // HOW????
-    // supabase.from('user_captain_clusters')
-    //   .delete()
-    //   .eq('user_role_id', 'id:user_role(user_profile_id=${person?.profile?.id})') // FIXME SYNTAX?
-    //   .eq('cluster_id', clusterId);
-  }
-
   Future<void> updateCaptains(String clusterId, List<Person> captains) async {
-    // index by id, for easy find
-    final newCaptains = { for (var c in captains) c.id: c };
+    final newIds = captains
+        .map((c) => c.profile?.id)
+        .whereType<String>()
+        .toSet();
 
-    // get existing captains, and iterate
-    final currentCaptains = await getCaptainsByClusterId(clusterId);
-    if (currentCaptains != null) {
-      for (var captain in currentCaptains.people) {
-        // - if in new list - remove from new list, continue
-        if (newCaptains.containsKey(captain?.id)) {
-          newCaptains.remove(captain?.id);
-          // newCaptains contains only new captains, not existing
-        }
-        // - if not - remove existing captain
-        else {
-          removeClusterCaptain(clusterId, captain);
-        }
-      }
+    final currentRows = await getCaptainsViewByClusterId(clusterId);
+    final currentIds = currentRows
+        .map((r) => r.userProfileId)
+        .whereType<String>()
+        .toSet();
+
+    for (final id in newIds.difference(currentIds)) {
+      await _addClusterCaptain(clusterId, id);
     }
+    for (final id in currentIds.difference(newIds)) {
+      await _removeClusterCaptain(clusterId, id);
+    }
+  }
 
-    for (var captain in newCaptains.values) {
-      addClusterCaptain(clusterId, captain);
+  Future<void> _addClusterCaptain(
+      String clusterId, String userProfileId) async {
+    final roleRow = await _clusterService.upsertUserRole(
+        userProfileId, APP_ROLES.subcom_agent);
+    await _clusterService.insertUserCaptainCluster(
+        clusterId, roleRow['id'] as String);
+  }
+
+  Future<void> _removeClusterCaptain(
+      String clusterId, String userProfileId) async {
+    final roleRow = await _clusterService.getUserRoleByProfileId(
+        userProfileId, APP_ROLES.subcom_agent);
+    if (roleRow == null) return;
+    final userRoleId = roleRow['id'] as String;
+
+    await _clusterService.deleteUserCaptainCluster(clusterId, userRoleId);
+
+    final remaining =
+        await _clusterService.getUserCaptainClustersByRoleId(userRoleId);
+    if (remaining.isEmpty) {
+      await _clusterService.deleteUserRole(userRoleId);
     }
   }
 

--- a/src/support_sphere/lib/data/services/cluster_service.dart
+++ b/src/support_sphere/lib/data/services/cluster_service.dart
@@ -134,4 +134,11 @@ class ClusterService {
   Future<void> deleteCluster(String clusterId) async {
     await supabase.from('clusters').delete().eq('id', clusterId);
   }
+
+  Future<PostgrestList?> getCaptainsViewByClusterId(String clusterId) async {
+    return await supabase
+        .from('cluster_captains_view')
+        .select('*')
+        .eq('cluster_id', clusterId);
+  }
 }

--- a/src/support_sphere/lib/data/services/cluster_service.dart
+++ b/src/support_sphere/lib/data/services/cluster_service.dart
@@ -2,6 +2,8 @@ import 'package:geodesy/geodesy.dart';
 import 'package:logging/logging.dart' show Logger;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:support_sphere/data/models/clusters.dart';
+import 'package:support_sphere/data/models/generated_classes.dart'
+    show UserRoles, UserCaptainClusters, APP_ROLES;
 import 'package:support_sphere/data/models/households.dart' show Household;
 import 'package:support_sphere/utils/supabase.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
@@ -135,10 +137,71 @@ class ClusterService {
     await supabase.from('clusters').delete().eq('id', clusterId);
   }
 
+  Future<PostgrestMap?> getUserRoleByProfileId(
+      String userProfileId, APP_ROLES role) async {
+    return await supabase
+        .from(UserRoles.table_name)
+        .select(UserRoles.c_id)
+        .eq(UserRoles.c_userProfileId, userProfileId)
+        .eq(UserRoles.c_role, role.name)
+        .maybeSingle();
+  }
+
+  Future<PostgrestMap> upsertUserRole(
+      String userProfileId, APP_ROLES role) async {
+    final existing = await getUserRoleByProfileId(userProfileId, role);
+    if (existing != null) return existing;
+    return await supabase
+        .from(UserRoles.table_name)
+        .insert(UserRoles.insert(
+          id: const UuidV4().generate(),
+          userProfileId: userProfileId,
+          role: role,
+        ))
+        .select(UserRoles.c_id)
+        .single();
+  }
+
+  Future<void> insertUserCaptainCluster(
+      String clusterId, String userRoleId) async {
+    await supabase
+        .from(UserCaptainClusters.table_name)
+        .insert(UserCaptainClusters.insert(
+          id: const UuidV4().generate(),
+          clusterId: clusterId,
+          userRoleId: userRoleId,
+        ));
+  }
+
+  Future<void> deleteUserCaptainCluster(
+      String clusterId, String userRoleId) async {
+    await supabase
+        .from(UserCaptainClusters.table_name)
+        .delete()
+        .eq(UserCaptainClusters.c_clusterId, clusterId)
+        .eq(UserCaptainClusters.c_userRoleId, userRoleId);
+  }
+
+  Future<List<UserCaptainClusters>> getUserCaptainClustersByRoleId(
+      String userRoleId) async {
+    final data = await supabase
+        .from(UserCaptainClusters.table_name)
+        .select()
+        .eq(UserCaptainClusters.c_userRoleId, userRoleId);
+    return UserCaptainClusters.converter(data);
+  }
+
+  Future<void> deleteUserRole(String userRoleId) async {
+    await supabase
+        .from(UserRoles.table_name)
+        .delete()
+        .eq(UserRoles.c_id, userRoleId);
+  }
+
   Future<PostgrestList?> getCaptainsViewByClusterId(String clusterId) async {
     return await supabase
         .from('cluster_captains_view')
-        .select('*')
+        .select('cluster_id, user_profile_id, given_name, family_name, nickname')
         .eq('cluster_id', clusterId);
   }
 }

--- a/src/support_sphere/lib/logic/cubit/manage_cluster_state.dart
+++ b/src/support_sphere/lib/logic/cubit/manage_cluster_state.dart
@@ -119,7 +119,7 @@ class ManageClusterCubit extends Cubit<ManageClusterState> {
     fetchHouseholds();
   }
 
-  void upsertCluster(Map<String, dynamic> clusterData) async {
+  Future<void> upsertCluster(Map<String, dynamic> clusterData) async {
     log.fine("Updating cluster: $clusterData");
     String clusterId = clusterData['id'];
     await _clusterRepo.upsertCluster(clusterData);

--- a/src/support_sphere/lib/logic/cubit/manage_neighborhood_state.dart
+++ b/src/support_sphere/lib/logic/cubit/manage_neighborhood_state.dart
@@ -49,7 +49,7 @@ class ManageNeighborhoodCubit extends Cubit<ManageNeighborhoodState> {
     neighborhoodChanged(clusters, info);
   }
 
-  void upsertCluster(Map<String, dynamic> cluster) async {
+  Future<void> upsertCluster(Map<String, dynamic> cluster) async {
     await _clusterRepo.upsertCluster(cluster);
     fetchNeighborhood();
   }

--- a/src/support_sphere/lib/presentation/components/add_item_button.dart
+++ b/src/support_sphere/lib/presentation/components/add_item_button.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class AddItemButton extends StatelessWidget {
+  const AddItemButton({
+    super.key,
+    required this.label,
+    required this.onPressed,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilledButton.tonalIcon(
+      onPressed: onPressed,
+      icon: const Icon(Icons.add),
+      label: Text(label),
+      style: FilledButton.styleFrom(
+        elevation: 2,
+        // side: BorderSide(color: Theme.of(context).colorScheme.outline),
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(8),
+        ),
+      ),
+    );
+  }
+}

--- a/src/support_sphere/lib/presentation/components/filter_search_bar.dart
+++ b/src/support_sphere/lib/presentation/components/filter_search_bar.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class FilterSearchBar extends StatelessWidget {
+  const FilterSearchBar({
+    super.key,
+    required this.labelText,
+    this.onQueryChanged,
+  });
+
+  final String labelText;
+  final void Function(String)? onQueryChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      child: TextField(
+        onChanged: onQueryChanged,
+        decoration: InputDecoration(
+          labelText: labelText,
+          border: const OutlineInputBorder(),
+          prefixIcon: const Icon(Icons.search),
+        ),
+      ),
+    );
+  }
+}

--- a/src/support_sphere/lib/presentation/components/people_select_list.dart
+++ b/src/support_sphere/lib/presentation/components/people_select_list.dart
@@ -136,46 +136,38 @@ class PersonSelectListState extends State<PersonSelectList> {
   }
 }
 
-class PersonSelectedField extends StatefulWidget {
-  const PersonSelectedField({super.key, required this.people, required this.onConfirm});
-  // TODO: Need a way to pre-select!
+class PersonSelectorField extends StatefulWidget {
+  const PersonSelectorField({
+    super.key,
+    required this.people,
+    required this.onConfirm,
+    this.initialValue = const [],
+    this.title,
+    this.buttonText,
+  });
+
   final List<Person> people;
   final Function(List<Person>) onConfirm;
+  final List<Person> initialValue;
+  final Text? title;
+  final Text? buttonText;
 
   @override
-  PersonSelectFieldState createState() => PersonSelectFieldState();
+  PersonSelectorFieldState createState() => PersonSelectorFieldState();
 }
 
-class PersonSelectFieldState extends State<PersonSelectedField> {
+class PersonSelectorFieldState extends State<PersonSelectorField> {
   @override
   Widget build(BuildContext context) {
-    final items = widget.people.map((person) => MultiSelectItem<Person>(person, person.name())).toList();
-    // TODO cluster captains should already be selected and sorted to the top.
-    // selecting a new captain puts it in the top part of the list
-    return MultiSelectDialogField(
+    final items = widget.people
+        .map((person) => MultiSelectItem<Person>(person, person.name()))
+        .toList();
+    return MultiSelectDialogField<Person>(
       items: items,
-      //title: Text("Cluster Members"), // FIXME text - PASS IN? "title"
-      //selectedColor: Colors.blue,
-      // decoration: BoxDecoration(
-      //   color: Colors.blue.shade100,
-      //   borderRadius: BorderRadius.all(Radius.circular(40)),
-      //   border: Border.all(
-      //     color: Colors.blue,
-      //     width: 2,
-      //   ),
-      // ),
-      // buttonIcon: Icon(
-      //   Icons.person_3_rounded,
-      //   color: Colors.blue,
-      // ),
-      //buttonText: Text("Cluster Captains", // FIXME text - PASS IN "buttonText"
-        //style: TextStyle(
-        //  color: Colors.blue.shade800,
-        //  fontSize: 16,
-      //),
-      onConfirm: (results) {
-        widget.onConfirm(results);
-      },
+      initialValue: widget.initialValue,
+      title: widget.title,
+      buttonText: widget.buttonText,
+      onConfirm: (results) => widget.onConfirm(results.cast<Person>()),
     );
   }
 }

--- a/src/support_sphere/lib/presentation/components/people_select_list.dart
+++ b/src/support_sphere/lib/presentation/components/people_select_list.dart
@@ -167,6 +167,8 @@ class PersonSelectorFieldState extends State<PersonSelectorField> {
       initialValue: widget.initialValue,
       title: widget.title,
       buttonText: widget.buttonText,
+      searchable: true,
+      searchHint: 'Search people...',
       onConfirm: (results) => widget.onConfirm(results.cast<Person>()),
     );
   }

--- a/src/support_sphere/lib/presentation/components/resource_search_bar.dart
+++ b/src/support_sphere/lib/presentation/components/resource_search_bar.dart
@@ -1,37 +1,15 @@
-
 import 'package:flutter/material.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/presentation/components/filter_search_bar.dart';
 
-class ResourceSearchBar extends StatefulWidget {
-  final void Function(String)? onQueryChanged;
-
+class ResourceSearchBar extends StatelessWidget {
   const ResourceSearchBar({super.key, this.onQueryChanged});
 
-  @override
-  _SearchBarState createState() => _SearchBarState();
-}
-
-class _SearchBarState extends State<ResourceSearchBar> {
-  String query = '';
-
-  void _defaultOnQueryChanged(String newQuery) {
-    setState(() {
-      query = newQuery;
-    });
-  }
+  final void Function(String)? onQueryChanged;
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.all(16),
-      child: TextField(
-        onChanged: widget.onQueryChanged ?? _defaultOnQueryChanged,
-        decoration: InputDecoration(
-          labelText: ResourceStrings.searchResources,
-          border: OutlineInputBorder(),
-          prefixIcon: Icon(Icons.search),
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => FilterSearchBar(
+        labelText: ResourceStrings.searchResources,
+        onQueryChanged: onQueryChanged,
+      );
 }

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_admin_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_admin_body.dart
@@ -9,6 +9,7 @@ import 'package:support_sphere/presentation/pages/main_app/admin/add_household_f
 import 'package:support_sphere/presentation/pages/main_app/admin/cluster_view_card.dart' show ClusterViewCard;
 import 'package:support_sphere/presentation/pages/main_app/admin/household_filter.dart';
 import 'package:support_sphere/presentation/pages/main_app/admin/household_search_bar.dart' show HouseholdSearchBar;
+import 'package:support_sphere/presentation/components/add_item_button.dart';
 import 'package:support_sphere/presentation/pages/main_app/admin/manage_household_card.dart';
 
 class ClusterAdminBody extends StatelessWidget {
@@ -129,12 +130,12 @@ class ManageClusterView extends StatelessWidget {
               ClusterViewCard(
                 cluster: state.cluster!,
                 members: state.members,
-                updateCluster: (clusterData) {
+                updateCluster: (clusterData) async {
                   final cubit = context.read<ManageClusterCubit>();
-                  cubit.upsertCluster(clusterData);
+                  await cubit.upsertCluster(clusterData);
                 },
               ) : Text(""),// EMPTY VIEW???
-            _ClusterAdminBody(addHouseholdOnPressed: addHouseholdOnPressed),
+            Expanded(child: _ClusterAdminBody(addHouseholdOnPressed: addHouseholdOnPressed)),
           ],
         );
       }
@@ -268,9 +269,9 @@ class _ClusterAdminBodyState extends State<_ClusterAdminBody> {
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
                 const SizedBox(width: 16),
-                ElevatedButton(
-                    onPressed: widget.addHouseholdOnPressed,
-                    child: Text(ClusterAdminStrings.addHousehold)),
+                AddItemButton(
+                    label: ClusterAdminStrings.addHousehold,
+                    onPressed: widget.addHouseholdOnPressed),
                 Expanded(child: HouseholdSearchBar(onQueryChanged: onQueryChanged)),
                 Expanded(
                   child: HouseholdFilter(
@@ -278,13 +279,15 @@ class _ClusterAdminBodyState extends State<_ClusterAdminBody> {
                 )),
               ],
             ),
-            Row(
-              children: [
-                Expanded(
-                  child: _ClusterViewSection(
-                      searchResults: _searchResults ?? state.households),
-                ),
-              ],
+            Expanded(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: _ClusterViewSection(
+                        searchResults: _searchResults ?? state.households),
+                  ),
+                ],
+              ),
             ),
           ],
         );
@@ -303,7 +306,6 @@ class _ClusterViewSection extends StatelessWidget {
     return BlocBuilder<ManageClusterCubit, ManageClusterState>(
       builder: (context, state) {
         return Container(
-            height: MediaQuery.of(context).size.height * 0.65,
             padding: const EdgeInsets.all(16),
             // TODO: Add pagination at some point
             child: (searchResults.isNotEmpty)

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_edit_form.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_edit_form.dart
@@ -1,7 +1,12 @@
 import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
-import 'package:support_sphere/data/models/clusters.dart';
+import 'package:support_sphere/data/models/clusters.dart' hide log;
+import 'package:support_sphere/data/models/person.dart';
+import 'package:support_sphere/data/repositories/cluster.dart' hide log;
+import 'package:support_sphere/data/repositories/user.dart';
 import 'package:support_sphere/presentation/components/auth/borders.dart';
+import 'package:support_sphere/presentation/components/people_select_list.dart'
+    show PersonSelectorField;
 
 // FORMZ: derive from col/attr list, props from entity...
 class EditClusterFormData extends Equatable {
@@ -26,14 +31,12 @@ class EditClusterFormData extends Equatable {
     );
   }
 
-
   @override
   List<Object?> get props => [
         name,
         meetingPlace,
         notes,
       ];
-
 
   EditClusterFormData copyWith({
     String? name,
@@ -47,7 +50,7 @@ class EditClusterFormData extends Equatable {
     );
   }
 
-  Map<String,dynamic> toUpsert(Cluster? old) {
+  Map<String, dynamic> toUpsert(Cluster? old) {
     log.fine("UPSERT --- $old");
     // copy over the values from the form
     // TODO: Could check against old for actual changes
@@ -55,7 +58,7 @@ class EditClusterFormData extends Equatable {
     // There is no way of doing this (currently) other than hard-coded maps
     // Design notes: Sometimes objects/classes get in the way. Nothing supports them in flutter.
     // No ORM, just boilerblate with opportunity for typos.
-    final Map<String,dynamic> upsertParams = {
+    final Map<String, dynamic> upsertParams = {
       'name': name,
       'meeting_place': meetingPlace,
       'notes': notes,
@@ -69,12 +72,14 @@ class EditClusterFormData extends Equatable {
   }
 }
 
-
 class ClusterEditForm extends StatefulWidget {
-  const ClusterEditForm({super.key, this.cluster, required void Function(Map<String,dynamic>) this.updateCluster});
+  const ClusterEditForm(
+      {super.key,
+      this.cluster,
+      required void Function(Map<String, dynamic>) this.updateCluster});
 
   final Cluster? cluster;
-  final Function(Map<String,dynamic>) updateCluster;
+  final Function(Map<String, dynamic>) updateCluster;
 
   @override
   State<ClusterEditForm> createState() => ClusterEditFormState();
@@ -82,8 +87,45 @@ class ClusterEditForm extends StatefulWidget {
 
 class ClusterEditFormState extends State<ClusterEditForm> {
   final _formKey = GlobalKey<FormState>();
-  late EditClusterFormData _formData = EditClusterFormData.fromCluster(widget.cluster);
-  late String addButtonLabel = widget.cluster != null ? "Update Cluster" : "Add Cluster";
+  late EditClusterFormData _formData =
+      EditClusterFormData.fromCluster(widget.cluster);
+  late String addButtonLabel =
+      widget.cluster != null ? "Update Cluster" : "Add Cluster";
+
+  List<Person> _allPeople = [];
+  List<Person> _selectedCaptains = [];
+  bool _isLoadingPeople = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _initPeopleAndCaptains();
+  }
+
+  Future<void> _initPeopleAndCaptains() async {
+    final membersMap = await UserRepository().getAllMembers();
+    final allPeople = membersMap.values.toList();
+
+    List<Person> currentCaptains = [];
+    if (widget.cluster != null) {
+      final rows = await ClusterRepository()
+          .getCaptainsViewByClusterId(widget.cluster!.id);
+      final captainProfileIds =
+          rows.map((r) => r.userProfileId).whereType<String>().toSet();
+      currentCaptains = captainProfileIds
+          .map((id) => membersMap[id])
+          .whereType<Person>()
+          .toList();
+    }
+
+    if (mounted) {
+      setState(() {
+        _allPeople = allPeople;
+        _selectedCaptains = currentCaptains;
+        _isLoadingPeople = false;
+      });
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -92,102 +134,112 @@ class ClusterEditFormState extends State<ClusterEditForm> {
     // if cluster set, load from
     return Card(
         child: Container(
-          margin: const EdgeInsets.all(15.0),
-          child: Form(
-            key: _formKey,
-            child: Column(
-              children: [
-                Center(
-                    child: Text(addButtonLabel, style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
-                )),
-                // Name of Cluster and Cluster Type
-                const SizedBox(height: 10),
-                TextFormField(
-                  initialValue: widget.cluster?.name,
-                  key: const Key('ClusterEditForm_name'),
-                  onSaved: (value) => _formData = _formData.copyWith(name: value),
-                  decoration: InputDecoration(
-                    labelText: "Cluster name", // FIXME strings
-                    //helperText: 'Name of the cluster',
-                    border: border(context),
-                    enabledBorder: border(context),
-                    focusedBorder: focusBorder(context)
+            margin: const EdgeInsets.all(15.0),
+            child: Form(
+              key: _formKey,
+              child: Column(
+                children: [
+                  Center(
+                      child: Text(
+                    addButtonLabel,
+                    style: TextStyle(fontSize: 16, fontWeight: FontWeight.bold),
+                  )),
+                  // Name of Cluster and Cluster Type
+                  const SizedBox(height: 10),
+                  TextFormField(
+                    initialValue: widget.cluster?.name,
+                    key: const Key('ClusterEditForm_name'),
+                    onSaved: (value) =>
+                        _formData = _formData.copyWith(name: value),
+                    decoration: InputDecoration(
+                        labelText: "Cluster name", // FIXME strings
+                        //helperText: 'Name of the cluster',
+                        border: border(context),
+                        enabledBorder: border(context),
+                        focusedBorder: focusBorder(context)),
                   ),
-                ),
-                const SizedBox(height: 10),
-                TextFormField(
-                  initialValue: widget.cluster?.meetingPlace,
-                  key: const Key('ClusterEditForm_meetingPlace'),
-                  onSaved: (value) => _formData = _formData.copyWith(meetingPlace: value),
-                  decoration: InputDecoration(
-                    labelText: "Meeting place",
-                    //helperText: 'Description of the cluster meeting place.',
-                    border: border(context),
-                    enabledBorder: border(context),
-                    focusedBorder: focusBorder(context)),
-                ),
-                const SizedBox(height: 10),
-                TextFormField(
-                  key: const Key('ClusterEditForm_notes'),
-                  onSaved: (value) => _formData = _formData.copyWith(notes: value),
-                  autovalidateMode: AutovalidateMode.onUserInteraction,
-                  decoration: InputDecoration(
-                      labelText: "Notes",
-                      //helperText: 'Notes about the cluster',
-                      border: border(context),
-                      enabledBorder: border(context),
-                      focusedBorder: focusBorder(context)),
-                ),
-                // cluster captains
-                Row(children: [
-                  Text(
-                    'Cluster captains:',
-                    style: TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.bold,
+                  const SizedBox(height: 10),
+                  TextFormField(
+                    initialValue: widget.cluster?.meetingPlace,
+                    key: const Key('ClusterEditForm_meetingPlace'),
+                    onSaved: (value) =>
+                        _formData = _formData.copyWith(meetingPlace: value),
+                    decoration: InputDecoration(
+                        labelText: "Meeting place",
+                        //helperText: 'Description of the cluster meeting place.',
+                        border: border(context),
+                        enabledBorder: border(context),
+                        focusedBorder: focusBorder(context)),
+                  ),
+                  const SizedBox(height: 10),
+                  TextFormField(
+                    key: const Key('ClusterEditForm_notes'),
+                    onSaved: (value) =>
+                        _formData = _formData.copyWith(notes: value),
+                    autovalidateMode: AutovalidateMode.onUserInteraction,
+                    decoration: InputDecoration(
+                        labelText: "Notes",
+                        //helperText: 'Notes about the cluster',
+                        border: border(context),
+                        enabledBorder: border(context),
+                        focusedBorder: focusBorder(context)),
+                  ),
+                  // cluster captains
+                  Row(children: [
+                    Text(
+                      'Cluster captains:',
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                  Text(
-                    '${widget.cluster?.captains}',
-                    style: TextStyle(
-                      fontSize: 15,
+                    const SizedBox(width: 8),
+                    _isLoadingPeople
+                        ? const SizedBox(
+                            width: 16,
+                            height: 16,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Expanded(
+                            child: PersonSelectorField(
+                              people: _allPeople,
+                              initialValue: _selectedCaptains,
+                              title: const Text('Select Cluster Captains'),
+                              buttonText: const Text('Select captains'),
+                              onConfirm: (captains) =>
+                                  setState(() => _selectedCaptains = captains),
+                            ),
+                          ),
+                  ]),
+                  const SizedBox(height: 50),
+                  // Buttons to Add Item or Cancel
+                  Row(children: [
+                    ElevatedButton(
+                      onPressed: () {
+                        _formKey.currentState!.save();
+                        if (_formKey.currentState!.validate()) {
+                          log.finer(
+                              "Original cluster: ${widget.cluster?.name} - ID: ${widget.cluster?.id} - ${widget.cluster?.geom}");
+                          final clusterUpsert =
+                              _formData.toUpsert(widget.cluster);
+                          clusterUpsert['captains'] = _selectedCaptains;
+                          log.finer("Updating cluster: $clusterUpsert");
+                          widget.updateCluster(clusterUpsert);
+                          Navigator.pop(context);
+                        }
+                      },
+                      child: Text(addButtonLabel),
                     ),
-                  ),
-                  ElevatedButton(
-                    onPressed: () {
-                      // FIXME: Implement user multiselect dialog
-                      //final updatedCaptains = [];
-                      //widget.cluster!.captains?.people = updatedCaptains;
-                    },
-                    child: Text('Add cluster captains')
-                  ),
-                ]),
-                const SizedBox(height: 50),
-                // Buttons to Add Item or Cancel
-                Row(children: [
-                  ElevatedButton(
-                    onPressed: () {
-                      _formKey.currentState!.save();
-                      if (_formKey.currentState!.validate()) {
-                        log.finer("Original cluster: ${widget.cluster?.name} - ID: ${widget.cluster?.id} - ${widget.cluster?.geom}");
-                        final clusterUpsert = _formData.toUpsert(widget.cluster);
-                        log.finer("Updating cluster: $clusterUpsert");
-                        widget.updateCluster(clusterUpsert);
+                    const SizedBox(width: 8),
+                    ElevatedButton(
+                      onPressed: () {
                         Navigator.pop(context);
-                      }
-                    },
-                    child: Text(addButtonLabel),
-                  ),
-                  const SizedBox(width: 8),
-                  ElevatedButton(
-                    onPressed: () { Navigator.pop(context); },
-                    child: const Text('Cancel'),
-                  ),
-                ]),
-              ],
-            ),
-          )
-        )
-    );
+                      },
+                      child: const Text('Cancel'),
+                    ),
+                  ]),
+                ],
+              ),
+            )));
   }
 }

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_edit_form.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_edit_form.dart
@@ -95,6 +95,7 @@ class ClusterEditFormState extends State<ClusterEditForm> {
   List<Person> _allPeople = [];
   List<Person> _selectedCaptains = [];
   bool _isLoadingPeople = true;
+  bool _isSaving = false;
 
   @override
   void initState() {
@@ -103,27 +104,32 @@ class ClusterEditFormState extends State<ClusterEditForm> {
   }
 
   Future<void> _initPeopleAndCaptains() async {
-    final membersMap = await UserRepository().getAllMembers();
-    final allPeople = membersMap.values.toList();
+    try {
+      final membersMap = await UserRepository().getAllMembers();
+      final allPeople = membersMap.values.toList();
 
-    List<Person> currentCaptains = [];
-    if (widget.cluster != null) {
-      final rows = await ClusterRepository()
-          .getCaptainsViewByClusterId(widget.cluster!.id);
-      final captainProfileIds =
-          rows.map((r) => r.userProfileId).whereType<String>().toSet();
-      currentCaptains = captainProfileIds
-          .map((id) => membersMap[id])
-          .whereType<Person>()
-          .toList();
-    }
+      List<Person> currentCaptains = [];
+      if (widget.cluster != null) {
+        final rows = await ClusterRepository()
+            .getCaptainsViewByClusterId(widget.cluster!.id);
+        final captainProfileIds =
+            rows.map((r) => r.userProfileId).whereType<String>().toSet();
+        currentCaptains = captainProfileIds
+            .map((id) => membersMap[id])
+            .whereType<Person>()
+            .toList();
+      }
 
-    if (mounted) {
-      setState(() {
-        _allPeople = allPeople;
-        _selectedCaptains = currentCaptains;
-        _isLoadingPeople = false;
-      });
+      if (mounted) {
+        setState(() {
+          _allPeople = allPeople;
+          _selectedCaptains = currentCaptains;
+          _isLoadingPeople = false;
+        });
+      }
+    } catch (e, stack) {
+      debugPrint('Failed to load people and captains: $e\n$stack');
+      if (mounted) setState(() => _isLoadingPeople = false);
     }
   }
 
@@ -215,20 +221,29 @@ class ClusterEditFormState extends State<ClusterEditForm> {
                   // Buttons to Add Item or Cancel
                   Row(children: [
                     ElevatedButton(
-                      onPressed: () {
-                        _formKey.currentState!.save();
-                        if (_formKey.currentState!.validate()) {
-                          log.finer(
-                              "Original cluster: ${widget.cluster?.name} - ID: ${widget.cluster?.id} - ${widget.cluster?.geom}");
-                          final clusterUpsert =
-                              _formData.toUpsert(widget.cluster);
-                          clusterUpsert['captains'] = _selectedCaptains;
-                          log.finer("Updating cluster: $clusterUpsert");
-                          widget.updateCluster(clusterUpsert);
-                          Navigator.pop(context);
-                        }
-                      },
-                      child: Text(addButtonLabel),
+                      onPressed: _isSaving
+                          ? null
+                          : () async {
+                              _formKey.currentState!.save();
+                              if (_formKey.currentState!.validate()) {
+                                log.finer(
+                                    "Original cluster: ${widget.cluster?.name} - ID: ${widget.cluster?.id} - ${widget.cluster?.geom}");
+                                final clusterUpsert =
+                                    _formData.toUpsert(widget.cluster);
+                                clusterUpsert['captains'] = _selectedCaptains;
+                                log.finer("Updating cluster: $clusterUpsert");
+                                setState(() => _isSaving = true);
+                                await widget.updateCluster(clusterUpsert);
+                                if (mounted) Navigator.pop(context);
+                              }
+                            },
+                      child: _isSaving
+                          ? const SizedBox(
+                              width: 16,
+                              height: 16,
+                              child: CircularProgressIndicator(strokeWidth: 2),
+                            )
+                          : Text(addButtonLabel),
                     ),
                     const SizedBox(width: 8),
                     ElevatedButton(

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_search_bar.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_search_bar.dart
@@ -1,37 +1,15 @@
-
 import 'package:flutter/material.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/presentation/components/filter_search_bar.dart';
 
-class ClusterSearchBar extends StatefulWidget {
-  final void Function(String)? onQueryChanged;
-
+class ClusterSearchBar extends StatelessWidget {
   const ClusterSearchBar({super.key, this.onQueryChanged});
 
-  @override
-  ClusterBarState createState() => ClusterBarState();
-}
-
-class ClusterBarState extends State<ClusterSearchBar> {
-  String query = '';
-
-  void _defaultOnQueryChanged(String newQuery) {
-    setState(() {
-      query = newQuery;
-    });
-  }
+  final void Function(String)? onQueryChanged;
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.all(16),
-      child: TextField(
-        onChanged: widget.onQueryChanged ?? _defaultOnQueryChanged,
-        decoration: InputDecoration(
-          labelText: NeighborhoodStrings.searchClusters,
-          border: OutlineInputBorder(),
-          prefixIcon: Icon(Icons.search),
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => FilterSearchBar(
+        labelText: NeighborhoodStrings.searchClusters,
+        onQueryChanged: onQueryChanged,
+      );
 }

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_view_card.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_view_card.dart
@@ -4,6 +4,8 @@ import 'package:support_sphere/data/models/clusters.dart';
 import 'package:support_sphere/constants/string_catalog.dart'
     show NeighborhoodStrings;
 import 'package:support_sphere/data/models/person.dart' show Person;
+import 'package:support_sphere/data/repositories/cluster.dart'
+    show ClusterRepository;
 import 'package:support_sphere/presentation/pages/main_app/admin/cluster_edit_form.dart'
     show ClusterEditForm;
 
@@ -25,17 +27,45 @@ class ClusterViewCard extends StatefulWidget {
 }
 
 class ClusterCardState extends State<ClusterViewCard> {
+  List<String> _captainNames = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _fetchCaptains();
+  }
+
+  Future<void> _fetchCaptains() async {
+    try {
+      final rows = await ClusterRepository()
+          .getCaptainsViewByClusterId(widget.cluster.id);
+      if (mounted) {
+        setState(() {
+          _captainNames = rows.map((r) {
+            final nick = r.nickname;
+            if (nick != null && nick.isNotEmpty) return nick;
+            return '${r.givenName ?? ''} ${r.familyName ?? ''}'.trim();
+          }).toList();
+        });
+      }
+    } catch (e, st) {
+      debugPrint(
+          'Failed to load captains for cluster ${widget.cluster.id}: $e\n$st');
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return GestureDetector(
         // detect the card has been clicked on, open the
         // details panel
         onTap: () => showDialog(
-            context: context,
-            builder: (BuildContext context) => Dialog(
-                child: ClusterEditForm(
-                    cluster: widget.cluster,
-                    updateCluster: widget.updateCluster))),
+                context: context,
+                builder: (BuildContext context) => Dialog(
+                    child: ClusterEditForm(
+                        cluster: widget.cluster,
+                        updateCluster: widget.updateCluster)))
+            .then((_) => _fetchCaptains()),
         child: Card(
             child: Column(
           mainAxisAlignment: MainAxisAlignment.start,
@@ -45,11 +75,6 @@ class ClusterCardState extends State<ClusterViewCard> {
                 padding: const EdgeInsets.all(8),
                 child: Row(
                   children: [
-                    // TODO: Implement Checkbox for selection
-                    // Checkbox(
-                    //   value: _isSelected,
-                    //   onChanged: (value) => _toggleSelection(value),
-                    // ),
                     SizedBox(
                       width: 200,
                       child: Row(
@@ -100,7 +125,7 @@ class ClusterCardState extends State<ClusterViewCard> {
                     Row(
                       children: [
                         Text(
-                          'Captains: ${widget.cluster.captains?.people.whereType<Person>().map((p) => p.name()).join(', ') ?? NeighborhoodStrings.captainNeeded}',
+                          'Captains: ${_captainNames.isEmpty ? NeighborhoodStrings.captainNeeded : _captainNames.join(', ')}',
                         ),
                       ],
                     ),

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_view_card.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/cluster_view_card.dart
@@ -1,9 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:support_sphere/data/models/clusters.dart';
+import 'package:support_sphere/constants/string_catalog.dart'
+    show NeighborhoodStrings;
 import 'package:support_sphere/data/models/person.dart' show Person;
-import 'package:support_sphere/presentation/components/people_select_list.dart'
-    show PersonSelectedField;
 import 'package:support_sphere/presentation/pages/main_app/admin/cluster_edit_form.dart'
     show ClusterEditForm;
 
@@ -99,33 +99,9 @@ class ClusterCardState extends State<ClusterViewCard> {
                   children: [
                     Row(
                       children: [
-                        Text('Captains: ${widget.cluster.captains}'),
-                        PersonSelectedField(
-                          people: widget.members,
-                          onConfirm: (List<Person> updatedCaptains) {
-                            widget.updateCluster({
-                              'id': widget.cluster.id,
-                              'captains': updatedCaptains
-                            });
-                          },
+                        Text(
+                          'Captains: ${widget.cluster.captains?.people.whereType<Person>().map((p) => p.name()).join(', ') ?? NeighborhoodStrings.captainNeeded}',
                         ),
-                        // ElevatedButton(
-                        //   style: ElevatedButton.styleFrom(backgroundColor: Colors.green),
-                        //   onPressed: () => showDialog<String>(
-                        //     context: context,
-                        //     builder: (BuildContext context) => Dialog.fullscreen(
-                        //       child: PersonSelectList(
-                        //         people: widget.members,
-                        //         onConfirm: (List<Person> updatedCaptains) {
-                        //           widget.updateCluster({
-                        //             'id': widget.cluster.id,
-                        //             'captains': updatedCaptains
-                        //           });
-                        //         })
-                        //     ),
-                        //   ),
-                        //   child: Text("Manage Captains", style: const TextStyle(color: Colors.white)),
-                        // ),
                       ],
                     ),
                   ],

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/household_search_bar.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/household_search_bar.dart
@@ -1,37 +1,15 @@
-
 import 'package:flutter/material.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/presentation/components/filter_search_bar.dart';
 
-class HouseholdSearchBar extends StatefulWidget {
-  final void Function(String)? onQueryChanged;
-
+class HouseholdSearchBar extends StatelessWidget {
   const HouseholdSearchBar({super.key, this.onQueryChanged});
 
-  @override
-  _SearchBarState createState() => _SearchBarState();
-}
-
-class _SearchBarState extends State<HouseholdSearchBar> {
-  String query = '';
-
-  void _defaultOnQueryChanged(String newQuery) {
-    setState(() {
-      query = newQuery;
-    });
-  }
+  final void Function(String)? onQueryChanged;
 
   @override
-  Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.all(16),
-      child: TextField(
-        onChanged: widget.onQueryChanged ?? _defaultOnQueryChanged,
-        decoration: InputDecoration(
-          labelText: ClusterAdminStrings.searchHouseholds,
-          border: OutlineInputBorder(),
-          prefixIcon: Icon(Icons.search),
-        ),
-      ),
-    );
-  }
+  Widget build(BuildContext context) => FilterSearchBar(
+        labelText: ClusterAdminStrings.searchHouseholds,
+        onQueryChanged: onQueryChanged,
+      );
 }

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/manage_neighborhood_card.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/manage_neighborhood_card.dart
@@ -20,27 +20,27 @@ class _NeighborhoodCardState extends State<ManageNeighborhoodCard> {
         children: [
           // Card Header
           Container(
-            alignment: Alignment.center,
-            padding: const EdgeInsets.all(8),
-            child: Row(
-              children: [
-                // TODO: Implement Checkbox for selection
-                // Checkbox(
-                //   value: _isSelected,
-                //   onChanged: (value) => _toggleSelection(value),
-                // ),
-                SizedBox(
-                  width: 200,
-                  child: Text(
-                    "Laurelhurst Neighborhood", // FIXME - store 'hood name somewhere
-                    style: TextStyle(
-                      fontSize: 15,
-                      fontWeight: FontWeight.bold,
+              alignment: Alignment.center,
+              padding: const EdgeInsets.all(8),
+              child: Row(
+                children: [
+                  // TODO: Implement Checkbox for selection
+                  // Checkbox(
+                  //   value: _isSelected,
+                  //   onChanged: (value) => _toggleSelection(value),
+                  // ),
+                  SizedBox(
+                    width: 200,
+                    child: Text(
+                      "Laurelhurst Neighborhood", // FIXME - store 'hood name somewhere
+                      style: TextStyle(
+                        fontSize: 15,
+                        fontWeight: FontWeight.bold,
+                      ),
                     ),
-                  ),
-                )
-              ],
-            )),
+                  )
+                ],
+              )),
           Container(
               padding: const EdgeInsets.all(8),
               child: Row(
@@ -55,7 +55,7 @@ class _NeighborhoodCardState extends State<ManageNeighborhoodCard> {
                       Text('''
                         Households: 2025
                         Clusters: 100
-                        Clusters without capatins: 26
+                        Clusters without captains: 26
                         '''),
                     ],
                   ),

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/neighborhood_admin_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/neighborhood_admin_body.dart
@@ -114,9 +114,9 @@ class EditClusterView extends StatelessWidget {
                       child: Container(
                         margin: const EdgeInsets.all(15.0),
                         child: ClusterEditForm(
-                          updateCluster: (clusterData) {
+                          updateCluster: (clusterData) async {
                             final cubit = context.read<ManageNeighborhoodCubit>();
-                            cubit.upsertCluster(clusterData);
+                            await cubit.upsertCluster(clusterData);
                           }
                         ),
                       ),
@@ -252,9 +252,9 @@ class _NeighborhoodViewSection extends StatelessWidget {
 
                       return ClusterViewCard(
                         cluster: cluster,
-                        updateCluster: (clusterData) {
+                        updateCluster: (clusterData) async {
                           final cubit = context.read<ManageNeighborhoodCubit>();
-                          cubit.upsertCluster(clusterData);
+                          await cubit.upsertCluster(clusterData);
                         },
                       );
                     },

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/neighborhood_admin_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/neighborhood_admin_body.dart
@@ -7,6 +7,7 @@ import 'package:support_sphere/presentation/pages/main_app/admin/cluster_edit_fo
 import 'package:support_sphere/presentation/pages/main_app/admin/cluster_search_bar.dart' show ClusterSearchBar;
 import 'package:support_sphere/presentation/pages/main_app/admin/cluster_view_card.dart' show ClusterViewCard;
 import 'package:support_sphere/presentation/pages/main_app/admin/manage_neighborhood_card.dart';
+import 'package:support_sphere/presentation/components/add_item_button.dart';
 import 'package:support_sphere/presentation/pages/main_app/admin/neighborhood_filter.dart';
 
 
@@ -203,9 +204,10 @@ class _NeighborhoodsBodyState extends State<_NeighborhoodsBody> {
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
                 const SizedBox(width: 16),
-                ElevatedButton(
-                    onPressed: widget.addClusterOnPressed,
-                    child: Text(NeighborhoodStrings.addCluster)),
+                AddItemButton(
+                  label: NeighborhoodStrings.addCluster,
+                  onPressed: widget.addClusterOnPressed,
+                ),
                 Expanded(child: ClusterSearchBar(onQueryChanged: onQueryChanged)),
                 Expanded(
                     child: NeighborhoodFilter(

--- a/src/support_sphere/lib/presentation/pages/main_app/admin/neighborhood_admin_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/admin/neighborhood_admin_body.dart
@@ -71,7 +71,7 @@ class ManageNeighborhoodView extends StatelessWidget {
     return Column(
       children: [
         ManageNeighborhoodCard(),
-        _NeighborhoodsBody(addClusterOnPressed: addClusterOnPressed),
+        Expanded(child: _NeighborhoodsBody(addClusterOnPressed: addClusterOnPressed)),
       ],
     );
   }
@@ -215,13 +215,15 @@ class _NeighborhoodsBodyState extends State<_NeighborhoodsBody> {
                 )),
               ],
             ),
-            Row(
-              children: [
-                Expanded(
-                  child: _NeighborhoodViewSection(
-                      searchResults: _searchResults ?? state.clusters),
-                ),
-              ],
+            Expanded(
+              child: Row(
+                children: [
+                  Expanded(
+                    child: _NeighborhoodViewSection(
+                        searchResults: _searchResults ?? state.clusters),
+                  ),
+                ],
+              ),
             ),
           ],
         );
@@ -240,7 +242,6 @@ class _NeighborhoodViewSection extends StatelessWidget {
     return BlocBuilder<ManageNeighborhoodCubit, ManageNeighborhoodState>(
       builder: (context, state) {
         return Container(
-            height: MediaQuery.of(context).size.height * 0.65,
             padding: const EdgeInsets.all(16),
             // TODO: Add pagination at some point
             child: (searchResults.isNotEmpty)

--- a/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_management_main_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/checklist/checklist_management_main_body.dart
@@ -8,6 +8,7 @@ import 'package:support_sphere/logic/bloc/auth/authentication_bloc.dart';
 import 'package:support_sphere/data/models/auth_user.dart';
 import 'package:support_sphere/data/models/checklist.dart';
 import 'package:support_sphere/constants/string_catalog.dart';
+import 'package:support_sphere/presentation/components/add_item_button.dart';
 
 class ChecklistManagementBody extends StatelessWidget {
   const ChecklistManagementBody({super.key});
@@ -84,18 +85,11 @@ class ChecklistManagementBody extends StatelessWidget {
                 padding: const EdgeInsets.symmetric(horizontal: 16),
                 child: Align(
                   alignment: Alignment.centerLeft,
-                  child: OutlinedButton.icon(
+                  child: AddItemButton(
+                    label: ChecklistStrings.newChecklist,
                     onPressed: () => context
                         .read<ChecklistManagementCubit>()
                         .showChecklistForm(),
-                    icon: const Icon(Icons.add),
-                    label: const Text(ChecklistStrings.newChecklist),
-                    style: OutlinedButton.styleFrom(
-                      backgroundColor: Colors.grey[300],
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(8),
-                      ),
-                    ),
                   ),
                 ),
               ),

--- a/src/support_sphere/lib/presentation/pages/main_app/manage_resources/manage_resources_body.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/manage_resources/manage_resources_body.dart
@@ -6,6 +6,7 @@ import 'package:support_sphere/presentation/components/manage_resource_card.dart
 import 'package:support_sphere/logic/cubit/manage_resource_cubit.dart';
 import 'package:support_sphere/presentation/components/resource_search_bar.dart';
 import 'package:support_sphere/presentation/components/resource_type_filter.dart';
+import 'package:support_sphere/presentation/components/add_item_button.dart';
 import 'package:support_sphere/presentation/pages/main_app/manage_resources/add_resource_form.dart';
 
 class ManageResourcesBody extends StatelessWidget {
@@ -190,9 +191,10 @@ class _ResourcesBodyState extends State<_ResourcesBody> {
               mainAxisAlignment: MainAxisAlignment.start,
               children: [
                 const SizedBox(width: 16),
-                ElevatedButton(
-                    onPressed: widget.addResourceOnPressed,
-                    child: Text(ResourceStrings.addResource)),
+                AddItemButton(
+                  label: ResourceStrings.addResource,
+                  onPressed: widget.addResourceOnPressed,
+                ),
                 Expanded(child: ResourceSearchBar(onQueryChanged: onQueryChanged)),
                 Expanded(
                     child: ResourceTypeFilter(

--- a/src/support_sphere/lib/presentation/pages/main_app/messages/inbox_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/messages/inbox_page.dart
@@ -98,9 +98,9 @@ class InboxView extends StatelessWidget {
                 child: Card(
                   color: switch (group.type) {
                     GROUP_CHAT_TYPE.request_consumable => Colors.blue[50],
-                    GROUP_CHAT_TYPE.request_durable    => Colors.yellow[50],
-                    GROUP_CHAT_TYPE.request_skill      => Colors.green[50],
-                    GROUP_CHAT_TYPE.chat               => null,
+                    GROUP_CHAT_TYPE.request_durable => Colors.yellow[50],
+                    GROUP_CHAT_TYPE.request_skill => Colors.green[50],
+                    GROUP_CHAT_TYPE.chat => null,
                   },
                   margin:
                       const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
@@ -108,18 +108,21 @@ class InboxView extends StatelessWidget {
                     leading: switch (group.type) {
                       GROUP_CHAT_TYPE.request_consumable => CircleAvatar(
                           backgroundColor: Colors.blue[300],
-                          child: const FaIcon(FontAwesomeIcons.glassWater, color: Colors.white),
+                          child: const FaIcon(FontAwesomeIcons.glassWater,
+                              color: Colors.white),
                         ),
                       GROUP_CHAT_TYPE.request_durable => CircleAvatar(
                           backgroundColor: Colors.yellow[600],
-                          child: const FaIcon(FontAwesomeIcons.wrench, color: Colors.white),
+                          child: const FaIcon(FontAwesomeIcons.wrench,
+                              color: Colors.white),
                         ),
                       GROUP_CHAT_TYPE.request_skill => CircleAvatar(
                           backgroundColor: Colors.green[400],
-                          child: const FaIcon(FontAwesomeIcons.helmetSafety, color: Colors.white),
+                          child: const FaIcon(FontAwesomeIcons.helmetSafety,
+                              color: Colors.white),
                         ),
                       GROUP_CHAT_TYPE.chat => CircleAvatar(
-                          child: Text(group.name[0].toUpperCase()),
+                          child: Text(chatAvatarText(group)),
                         ),
                     },
                     title: Text(group.name),
@@ -152,6 +155,11 @@ class InboxView extends StatelessWidget {
         child: const Icon(Icons.add),
       ),
     );
+  }
+
+  String chatAvatarText(ChatGroup group) {
+    if (group.name.isEmpty) return '[]';
+    return group.name[0].toUpperCase();
   }
 
   void _navigateToChat(BuildContext context, ChatGroup group) async {

--- a/src/support_sphere_py/src/support_sphere/models/enums/app_roles.py
+++ b/src/support_sphere_py/src/support_sphere/models/enums/app_roles.py
@@ -2,10 +2,10 @@ from enum import Enum
 
 
 class AppRoles(Enum):
-    USER = ("user", "Referring to those who live in the community, work in the community, or a business entity or a non-profit like a church etc")
-    SUBCOM_AGENT = ("subcommunity_agent", "Cluster captains of the community")
-    COM_ADMIN = ("community_admin", "Community steering committee member")
-    ADMIN = ("admin", "A University of Washington Team member")
+    user = ("user", "Referring to those who live in the community, work in the community, or a business entity or a non-profit like a church etc")
+    subcom_agent = ("subcommunity_agent", "Cluster captains of the community")
+    com_admin = ("community_admin", "Community steering committee member")
+    admin = ("admin", "A University of Washington Team member")
 
     def __init__(self, role, description):
         self.role = role

--- a/src/support_sphere_py/src/support_sphere/scripts/update_db_sample_data.py
+++ b/src/support_sphere_py/src/support_sphere/scripts/update_db_sample_data.py
@@ -111,7 +111,7 @@ def populate_user_details():
                     profile = UserProfile(user=user)
                     user_profile = UserProfileRepository.add(profile)
 
-                    user_role = UserRole(user_profile=user_profile, role=AppRoles.USER)
+                    user_role = UserRole(user_profile=user_profile, role=AppRoles.user)
                     BaseRepository.add(user_role)
 
             # Create People Entry
@@ -247,11 +247,11 @@ def authenticate_user_signup_signin_signout_via_supabase():
 
 
 def update_user_permissions_roles_by_cluster():
-    role_1 = RolePermission(role=AppRoles.ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_READ)
-    role_2 = RolePermission(role=AppRoles.ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_CREATE)
-    role_3 = RolePermission(role=AppRoles.COM_ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_CREATE)
-    role_4 = RolePermission(role=AppRoles.COM_ADMIN, permission=AppPermissions.OPERATIONAL_EVENT_READ)
-    role_5 = RolePermission(role=AppRoles.SUBCOM_AGENT, permission=AppPermissions.OPERATIONAL_EVENT_READ)
+    role_1 = RolePermission(role=AppRoles.admin, permission=AppPermissions.OPERATIONAL_EVENT_READ)
+    role_2 = RolePermission(role=AppRoles.admin, permission=AppPermissions.OPERATIONAL_EVENT_CREATE)
+    role_3 = RolePermission(role=AppRoles.com_admin, permission=AppPermissions.OPERATIONAL_EVENT_CREATE)
+    role_4 = RolePermission(role=AppRoles.com_admin, permission=AppPermissions.OPERATIONAL_EVENT_READ)
+    role_5 = RolePermission(role=AppRoles.subcom_agent, permission=AppPermissions.OPERATIONAL_EVENT_READ)
 
     BaseRepository.add(role_1)
     BaseRepository.add(role_2)
@@ -261,7 +261,7 @@ def update_user_permissions_roles_by_cluster():
 
     user = UserRepository.find_by_email('adam.abacus@example.com')
     user_role = UserRoleRepository.find_by_user_profile_id(user.id)
-    user_role.role = AppRoles.SUBCOM_AGENT
+    user_role.role = AppRoles.subcom_agent
     BaseRepository.add(user_role)
 
     all_clusters = BaseRepository.select_all(Cluster)
@@ -270,7 +270,7 @@ def update_user_permissions_roles_by_cluster():
 
     user = UserRepository.find_by_email('beth.bodmas@example.com')
     user_role = UserRoleRepository.find_by_user_profile_id(user.id)
-    user_role.role = AppRoles.COM_ADMIN
+    user_role.role = AppRoles.com_admin
     BaseRepository.add(user_role)
 
 


### PR DESCRIPTION
Fixed bug in person selector for Neighborhood admin panel, and unified button style into consistent AddItemButton
Made a new view in supabase to simplify db queries for cluster captains:

 CREATE OR REPLACE VIEW cluster_captains_view AS
WITH crs AS (
  SELECT
    c.id AS cluster_id, c.name AS cluster_name,
    uc.user_role_id
  FROM
    clusters AS c
      JOIN user_captain_clusters AS uc ON uc.cluster_id = c.id
),
urp AS (
  SELECT
    ur.id, ur.user_profile_id, ur.role AS user_role,
    p.given_name, p.family_name, p.nickname
  FROM
    user_roles AS ur
      JOIN people AS p ON ur.user_profile_id = p.user_profile_id
)
SELECT
  crs.cluster_id, crs.cluster_name, 
  urp.user_role, urp.user_profile_id, urp.given_name, urp.family_name, urp.nickname
FROM
  crs
    JOIN urp ON urp.id = crs.user_role_id;