### PR TITLE
(feat): blocking users (partial implementation)

### DIFF
--- a/src/support_sphere/analysis_options.yaml
+++ b/src/support_sphere/analysis_options.yaml
@@ -1,3 +1,8 @@
+analyzer:
+  errors:
+    no_logic_in_create_state: ignore
+  exclude:
+    - lib/data/models/generated_classes.dart
 include: package:flutter_lints/flutter.yaml
 
 linter:

--- a/src/support_sphere/lib/data/models/generated_classes.dart
+++ b/src/support_sphere/lib/data/models/generated_classes.dart
@@ -69,6 +69,7 @@ extension SupadartClient on SupabaseClient {
   SupabaseQueryBuilder get user_profiles => from('user_profiles');
   SupabaseQueryBuilder get user_checklists => from('user_checklists');
   SupabaseQueryBuilder get group_members => from('group_members');
+  SupabaseQueryBuilder get blocks => from('blocks');
   SupabaseQueryBuilder get user_resources_view => from('user_resources_view');
   SupabaseQueryBuilder get requests => from('requests');
   SupabaseQueryBuilder get clusters => from('clusters');
@@ -3480,6 +3481,110 @@ class GroupMembers implements SupadartClass<GroupMembers> {
     return GroupMembers(
       groupId: groupId == _unset ? this.groupId : groupId as String,
       profileId: profileId == _unset ? this.profileId : profileId as String,
+    );
+  }
+}
+
+class Blocks implements SupadartClass<Blocks> {
+  final String blocker;
+  final String blockee;
+  final DateTime createdAt;
+
+  const Blocks({
+    required this.blocker,
+    required this.blockee,
+    required this.createdAt,
+  });
+
+  static String get table_name => 'blocks';
+  static String get c_blocker => 'blocker';
+  static String get c_blockee => 'blockee';
+  static String get c_createdAt => 'created_at';
+
+  static List<Blocks> converter(List<Map<String, dynamic>> data) {
+    return data.map(Blocks.fromJson).toList();
+  }
+
+  static Blocks converterSingle(Map<String, dynamic> data) {
+    return Blocks.fromJson(data);
+  }
+
+  static Map<String, dynamic> _generateMap({
+    String? blocker,
+    String? blockee,
+    DateTime? createdAt,
+  }) {
+    return {
+      if (blocker != null) 'blocker': blocker,
+      if (blockee != null) 'blockee': blockee,
+      if (createdAt != null) 'created_at': createdAt.toUtc().toIso8601String(),
+    };
+  }
+
+  static Map<String, dynamic> insert({
+    String? blocker,
+    String? blockee,
+    DateTime? createdAt,
+  }) {
+    return _generateMap(
+      blocker: blocker,
+      blockee: blockee,
+      createdAt: createdAt,
+    );
+  }
+
+  static Map<String, dynamic> update({
+    String? blocker,
+    String? blockee,
+    DateTime? createdAt,
+  }) {
+    return _generateMap(
+      blocker: blocker,
+      blockee: blockee,
+      createdAt: createdAt,
+    );
+  }
+
+  factory Blocks.fromJson(Map<String, dynamic> jsonn) {
+    return Blocks(
+      blocker: jsonn['blocker'] != null ? jsonn['blocker'].toString() : '',
+      blockee: jsonn['blockee'] != null ? jsonn['blockee'].toString() : '',
+      createdAt: jsonn['created_at'] != null
+          ? DateTime.parse(jsonn['created_at'].toString())
+          : DateTime.fromMillisecondsSinceEpoch(0),
+    );
+  }
+
+  static Object New({
+    String? blocker,
+    String? blockee,
+    DateTime? createdAt,
+  }) {
+    return {
+      if (blocker != null) 'blocker': blocker,
+      if (blockee != null) 'blockee': blockee,
+      if (createdAt != null) 'created_at': createdAt,
+    };
+  }
+
+  Map<String, dynamic> toJson() {
+    return _generateMap(
+      blocker: blocker,
+      blockee: blockee,
+      createdAt: createdAt,
+    );
+  }
+
+  static const _unset = Object();
+  Blocks copyWith({
+    Object? blocker = _unset,
+    Object? blockee = _unset,
+    Object? createdAt = _unset,
+  }) {
+    return Blocks(
+      blocker: blocker == _unset ? this.blocker : blocker as String,
+      blockee: blockee == _unset ? this.blockee : blockee as String,
+      createdAt: createdAt == _unset ? this.createdAt : createdAt as DateTime,
     );
   }
 }

--- a/src/support_sphere/lib/data/repositories/chat_repository.dart
+++ b/src/support_sphere/lib/data/repositories/chat_repository.dart
@@ -68,7 +68,7 @@ class ChatRepository {
   }
 
 // Create new chat group with member profile IDs. Returns new group ID.
-  Future<String> createGroupWithProfiles(
+  Future<ChatGroup?> createGroupWithProfiles(
       {required String name,
       String? description,
       required String createdByProfileId,
@@ -96,7 +96,7 @@ class ChatRepository {
         return true;
       }).firstOrNull;
       if (existing != null) {
-        return existing.id;
+        return existing;
       }
     }
     final cleanDescription =
@@ -141,7 +141,7 @@ class ChatRepository {
 
     await supabase.from('group_members').insert(memberRows);
 
-    return groupId;
+    return getGroup(groupId, createdByProfileId);
   }
 
   Future<String> _getNextGroupName({
@@ -157,7 +157,7 @@ class ChatRepository {
     return result as String;
   }
 
-  Future<String> createDirectRequestGroup({
+  Future<ChatGroup?> createDirectRequestGroup({
     required String name,
     String? description,
     required String createdByProfileId,
@@ -212,5 +212,34 @@ class ChatRepository {
   Future<void> deleteGroup(String id) async {
     await supabase.from('messages').delete().eq('to_id', id);
     await supabase.from('groups').delete().eq('id', id);
+  }
+
+  Future<ChatGroup?> getGroup(String id, String currentUid) async {
+    final response = await supabase.groups.select('''
+      id,
+      name,
+      description,
+      type,
+      group_members(
+        profile_id,
+        user_profiles(
+          people(
+            given_name,
+            user_profile_id
+          )
+        )
+      )
+    ''').eq(Groups.c_id, id).maybeSingle().withConverter(
+          (resp) {
+            if (resp == null) return null;
+            List<Map<String, dynamic>> members = (resp['group_members'] as List)
+                .map((e) => (e as Map<String, dynamic>)['user_profiles']
+                    ['people'] as Map<String, dynamic>)
+                .toList();
+            return (Groups.fromJson(resp), People.converter(members));
+          },
+        );
+    if (response == null) return null;
+    return responseToChatGroup(response, currentUid);
   }
 }

--- a/src/support_sphere/lib/data/repositories/resource.dart
+++ b/src/support_sphere/lib/data/repositories/resource.dart
@@ -143,7 +143,7 @@ class ResourceRepository {
         'Skill' => GROUP_CHAT_TYPE.request_skill,
         _ => GROUP_CHAT_TYPE.request_consumable,
       };
-      final groupId = await _chatRepository.createDirectRequestGroup(
+      final groupChat = await _chatRepository.createDirectRequestGroup(
         name: await _groupNameForRequest(
           candidate,
           allocated,
@@ -154,6 +154,12 @@ class ResourceRepository {
         otherProfileId: candidate.profileId,
         type: groupType,
       );
+
+      if (groupChat == null) {
+        throw Exception(
+          'failed to create a chat with the person to request from',
+        );
+      }
 
       final requestRow = await _resourceService.reserveRequestCandidate(
         resourceId: resourceRequest.resourceId,
@@ -176,7 +182,7 @@ class ResourceRepository {
 
       await _messagesRepository.sendMessage(
         fromProfileId: requesterProfileId,
-        groupId: groupId,
+        groupId: groupChat.id,
         text: buf.toString(),
         messageType: 'resource_request',
         requestId: requestRow['id'] as String,

--- a/src/support_sphere/lib/data/repositories/user.dart
+++ b/src/support_sphere/lib/data/repositories/user.dart
@@ -194,4 +194,14 @@ class UserRepository {
       return null;
     }
   }
+
+  Future<void> blockUser({
+    required String blockerId,
+    required String blockeeId,
+  }) async {
+    await _userService.blockPerson(
+      blockerId: blockerId,
+      blockeeId: blockeeId,
+    );
+  }
 }

--- a/src/support_sphere/lib/data/services/auth_service.dart
+++ b/src/support_sphere/lib/data/services/auth_service.dart
@@ -8,7 +8,7 @@ import 'package:uuid/v4.dart' show UuidV4;
 
 final _log = Logger('AuthService');
 
-class AuthService extends Equatable{
+class AuthService extends Equatable {
   static final GoTrueClient _supabaseAuth = supabase.auth;
   final SupabaseClient _supabaseClient = supabase;
 
@@ -16,16 +16,25 @@ class AuthService extends Equatable{
   Session? getUserSession() => _supabaseAuth.currentSession;
 
   Future<Map<String, dynamic>?> isSignupCodeValid(String code) async {
-    return await _supabaseClient.from('signup_codes').select().eq('code', code).maybeSingle();
+    return await _supabaseClient
+        .from('signup_codes')
+        .select()
+        .eq('code', code)
+        .maybeSingle();
   }
 
   Future<String?> getSignUpCodeForHousehold(String householdId) async {
-    PostgrestMap? result = await _supabaseClient.from('signup_codes').select().eq('household_id', householdId).maybeSingle();
+    PostgrestMap? result = await _supabaseClient
+        .from('signup_codes')
+        .select()
+        .eq('household_id', householdId)
+        .maybeSingle();
     _log.finer("get SIGNUP CODE for $householdId: $result");
     return result?['code'];
   }
 
-  Future<void> logUseOfSignupCode(String email, String householdId, String code) async {
+  Future<void> logUseOfSignupCode(
+      String email, String householdId, String code) async {
     // add log to table
     await _supabaseClient.from('signup_logs').insert({
       'id': const UuidV4().generate(),
@@ -38,34 +47,47 @@ class AuthService extends Equatable{
   }
 
   Future<void> invalidateSignupCode(String code) async {
-    await _supabaseClient.rpc('invalidate_signup_code', params: {'input_code': code});
+    await _supabaseClient
+        .rpc('invalidate_signup_code', params: {'input_code': code});
   }
 
   // Delete the users account
-  Future <void> deleteMyAccount() async {
+  Future<void> deleteMyAccount() async {
     String? userId = _supabaseAuth.currentUser?.id;
     await _supabaseClient.rpc('delete_user', params: {'user_id': userId});
   }
 
   // Delete an account
-  Future <void> deleteUser(String userId) async {
+  Future<void> deleteUser(String userId) async {
     await _supabaseClient.rpc('delete_user', params: {'user_id': userId});
   }
 
-  Future<AuthResponse> signUpWithEmailAndPassword(String email, String password) async {
+  Future<AuthResponse> signUpWithEmailAndPassword(
+      String email, String password) async {
     // TODO: Add email verification in the future
-    final response = await _supabaseAuth.signUp(email: email, password: password);
+    final response =
+        await _supabaseAuth.signUp(email: email, password: password);
     return response;
   }
 
-  Future<AuthResponse> signInWithEmailAndPassword(String email, String password) async {
+  Future<AuthResponse> signInWithEmailAndPassword(
+      String email, String password) async {
     _log.fine("login: $email, $_supabaseAuth");
-    final response = await _supabaseAuth.signInWithPassword(email: email, password: password);
+    final response = await _supabaseAuth.signInWithPassword(
+        email: email, password: password);
     _log.fine("login response: $response");
     return response;
   }
 
-  Stream<Session?> getCurrentSession() => _supabaseAuth.onAuthStateChange.map((data) => data.session);
+  Future<User?> reauthSignedInUser(String password) async {
+    String? email = _supabaseAuth.currentUser?.email;
+    if (email == null || email.isEmpty) throw 'failed to get the email';
+    final response = await signInWithEmailAndPassword(email, password);
+    return response.user;
+  }
+
+  Stream<Session?> getCurrentSession() =>
+      _supabaseAuth.onAuthStateChange.map((data) => data.session);
 
   Future<void> signOut() async => await _supabaseAuth.signOut();
 
@@ -83,7 +105,8 @@ class AuthService extends Equatable{
 
       // RPC Workaround:
       // await _supabaseClient.rpc('clear_user_phone', params: { 'user_id': _supabaseAuth.currentUser?.id });
-      return Future.value(UserResponse.fromJson(_supabaseAuth.currentUser?.toJson() ?? {}));
+      return Future.value(
+          UserResponse.fromJson(_supabaseAuth.currentUser?.toJson() ?? {}));
     } else {
       return await _supabaseAuth.updateUser(
         UserAttributes(

--- a/src/support_sphere/lib/data/services/user_service.dart
+++ b/src/support_sphere/lib/data/services/user_service.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart' show Logger;
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:support_sphere/data/models/generated_classes.dart';
 import 'package:support_sphere/utils/supabase.dart';
 import 'package:uuid/v4.dart';
 
@@ -31,7 +32,8 @@ class UserService {
   }
 
   /// Retrieves the household members by household id.
-  Future<PostgrestList?> getHouseholdMembersByHouseholdId(String householdId) async {
+  Future<PostgrestList?> getHouseholdMembersByHouseholdId(
+      String householdId) async {
     log.fine("getting household members for household id=$householdId");
     return await supabase.from('people_groups').select('''
       people(
@@ -45,7 +47,6 @@ class UserService {
       )
     ''').eq('household_id', householdId);
   }
-
 
   Future<PostgrestList> getClusterMembers(String clusterId) async {
     return await supabase.from('people_groups').select('''
@@ -138,7 +139,9 @@ class UserService {
 
     if (address != null) payload['address'] = address;
     if (pets != null) payload['pets'] = pets;
-    if (accessibilityNeeds != null) payload['accessibility_needs'] = accessibilityNeeds;
+    if (accessibilityNeeds != null) {
+      payload['accessibility_needs'] = accessibilityNeeds;
+    }
     if (notes != null) payload['notes'] = notes;
 
     await supabase.from('households').update(payload).eq('id', id);
@@ -154,5 +157,15 @@ class UserService {
       'people_id': personId,
       'household_id': householdId,
     });
+  }
+
+  Future<void> blockPerson({
+    required String blockerId,
+    required String blockeeId,
+  }) async {
+    await supabase.blocks.insert(Blocks.insert(
+      blocker: blockerId,
+      blockee: blockeeId,
+    ));
   }
 }

--- a/src/support_sphere/lib/presentation/components/reauth_dialog.dart
+++ b/src/support_sphere/lib/presentation/components/reauth_dialog.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:support_sphere/data/services/auth_service.dart';
+import 'package:support_sphere/presentation/components/confirmation_dialog.dart';
+
+class ReauthDialog {
+  late final ConfirmationDialog _confirmationDialog;
+  final controller = TextEditingController();
+  final BuildContext _context;
+  ReauthDialog(this._context) {
+    _confirmationDialog = ConfirmationDialog(
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.pop(_context),
+          child: const Text('Cancel'),
+        ),
+        ElevatedButton(
+          onPressed: () => Navigator.pop(_context, controller.text),
+          child: const Text('Continue'),
+        ),
+      ],
+      title: Text('Confirm your password'),
+      content: TextField(
+        controller: controller,
+        obscureText: true,
+        decoration: const InputDecoration(labelText: 'Current password'),
+      ),
+    );
+  }
+
+  Future<String?> show() {
+    return _confirmationDialog.show<String>(_context);
+  }
+
+  Future<bool> perform(AuthService authService) async {
+    final String? password = await show();
+    if (password == null || password.isEmpty) return false;
+    return await AuthService().reauthSignedInUser(password) != null;
+  }
+}

--- a/src/support_sphere/lib/presentation/pages/main_app/messages/create_chat_group_sheet.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/messages/create_chat_group_sheet.dart
@@ -78,15 +78,21 @@ class _CreateChatGroupSheetState extends State<CreateChatGroupSheet> {
     setState(() => _isSaving = true);
 
     try {
-      final groupId = await widget.repo.createGroupWithProfiles(
+      final groupChat = await widget.repo.createGroupWithProfiles(
         name: _nameController.text,
         description: _descriptionController.text,
         createdByProfileId: widget.myProfileId,
         memberProfileIds: _selectedProfileIds.toList(),
       );
+      if (groupChat == null) {
+        throw Exception(
+          'failed to create a group chat',
+        );
+      }
 
       if (!mounted) return;
-      Navigator.of(context).pop((groupId, _nameController.text));
+      // ignore: unnecessary_non_null_assertion
+      Navigator.of(context).pop(groupChat!);
     } catch (e) {
       if (!mounted) return;
       setState(() => _isSaving = false);

--- a/src/support_sphere/lib/presentation/pages/main_app/messages/inbox_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/messages/inbox_page.dart
@@ -13,7 +13,6 @@ import 'package:support_sphere/data/models/chat_group.dart';
 import 'package:support_sphere/presentation/pages/main_app/messages/create_chat_group_sheet.dart';
 import 'package:support_sphere/data/repositories/chat_repository.dart';
 import 'package:support_sphere/data/repositories/message.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 ///TODO- make sure preloader is the same across all pages, potentially move to a shared widget?
 const preloader =
@@ -167,10 +166,7 @@ class InboxView extends StatelessWidget {
     await Navigator.push(
       context,
       MaterialPageRoute(
-        builder: (context) => MessagesPage(
-          groupId: group.id,
-          groupName: group.name,
-        ),
+        builder: (context) => MessagesPage(group: group),
       ),
     );
     if (!context.mounted) return;
@@ -184,7 +180,7 @@ class InboxView extends StatelessWidget {
     final myProfileId = context.read<AuthenticationBloc>().state.user.uuid;
     final chatRepo = ChatRepository();
 
-    final result = await showModalBottomSheet<(String, String)>(
+    final chatGroup = await showModalBottomSheet<ChatGroup>(
       context: context,
       isScrollControlled: true,
       useSafeArea: true,
@@ -194,15 +190,13 @@ class InboxView extends StatelessWidget {
       ),
     );
 
-    if (result != null && context.mounted) {
+    if (chatGroup != null && context.mounted) {
       await context.read<InboxCubit>().fetchGroups();
-      final (groupId, groupName) = result;
       if (context.mounted) {
         Navigator.push(
           context,
           MaterialPageRoute(
-            builder: (_) =>
-                MessagesPage(groupId: groupId, groupName: groupName),
+            builder: (_) => MessagesPage(group: chatGroup),
           ),
         );
       }

--- a/src/support_sphere/lib/presentation/pages/main_app/messages/messages_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/messages/messages_page.dart
@@ -8,6 +8,8 @@ import 'package:support_sphere/data/models/person.dart';
 import 'package:support_sphere/data/repositories/cluster.dart';
 import 'package:support_sphere/data/repositories/message.dart';
 import 'package:support_sphere/data/repositories/user.dart';
+import 'package:support_sphere/data/services/auth_service.dart';
+import 'package:support_sphere/presentation/components/reauth_dialog.dart';
 import 'package:support_sphere/utils/supabase.dart';
 import 'package:timeago/timeago.dart';
 
@@ -74,7 +76,19 @@ class MessagesState extends State<MessagesPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: Text(widget.groupName)),
+      appBar: AppBar(
+        title: Text(widget.groupName),
+        actions: [
+          TextButton(
+            onPressed: () async {
+              if (await ReauthDialog(context).perform(AuthService())) {
+                // perform block action
+              }
+            },
+            child: Text('Block'),
+          ),
+        ],
+      ),
       body: StreamBuilder<List<Message>>(
         stream:
             messageRepo.messagesFor(supabase.auth.currentUser!, widget.groupId),

--- a/src/support_sphere/lib/presentation/pages/main_app/messages/messages_page.dart
+++ b/src/support_sphere/lib/presentation/pages/main_app/messages/messages_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:logging/logging.dart' show Logger;
+import 'package:support_sphere/data/models/chat_group.dart';
 import 'package:support_sphere/data/models/generated_classes.dart';
 import 'package:support_sphere/data/models/messages.dart';
 import 'package:support_sphere/data/models/person.dart';
@@ -22,17 +23,20 @@ final log = Logger('MessagesPage');
 ///TODO- add ability to send "urgent" messages (red highlight, icon) for cluster captains
 
 class MessagesPage extends StatefulWidget {
-  final String groupId;
-  final String groupName;
+  final ChatGroup group;
 
-  const MessagesPage(
-      {super.key, required this.groupId, required this.groupName});
+  const MessagesPage({
+    super.key,
+    required this.group,
+  });
 
   @override
-  State<MessagesPage> createState() => MessagesState();
+  State<MessagesPage> createState() => MessagesState(group: group);
 }
 
 class MessagesState extends State<MessagesPage> {
+  final ChatGroup group;
+
   final UserRepository userRepo = UserRepository();
   final MessagesRepository messageRepo = MessagesRepository();
   final ClusterRepository clusterRepo = ClusterRepository();
@@ -42,9 +46,11 @@ class MessagesState extends State<MessagesPage> {
   final Map<String, Person> profileCache = {};
   late final String myUserId;
 
+  MessagesState({required this.group});
+
   @override
   void initState() {
-    log.fine('🚀 initState groupId: "${widget.groupId}"');
+    log.fine('🚀 initState groupId: "${group.id}"');
     super.initState();
 
     myUserId = supabase.auth.currentUser!.id;
@@ -54,16 +60,16 @@ class MessagesState extends State<MessagesPage> {
   }
 
   Future<void> _loadInitialData() async {
-    log.fine('✅ Group ID: ${widget.groupId}');
+    log.fine('✅ Group ID: ${group.id}');
     log.fine('✅ My User: $myUserId');
     setState(() => {});
     final user = await userRepo.getPersonProfileByUserId(userId: myUserId);
     log.fine("MY USER ID: $myUserId, profile: ${user!.profile!.id}");
-    log.fine("MY GROUP ID: $widget.groupId");
+    log.fine("MY GROUP ID: $group.id");
     final allUsers = await userRepo.getAllMembers();
     profileCache.addAll(allUsers);
     // mark all messages read
-    await messageRepo.markMessagesRead(widget.groupId, myUserId);
+    await messageRepo.markMessagesRead(group.id, myUserId);
     if (!mounted) return;
     setState(() => {});
   }
@@ -77,21 +83,26 @@ class MessagesState extends State<MessagesPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.groupName),
+        title: Text(group.name),
         actions: [
-          TextButton(
-            onPressed: () async {
-              if (await ReauthDialog(context).perform(AuthService())) {
-                // perform block action
-              }
-            },
-            child: Text('Block'),
-          ),
+          if (group.members.length == 2)
+            TextButton(
+              onPressed: () async {
+                if (await ReauthDialog(context).perform(AuthService())) {
+                  userRepo.blockUser(
+                    blockerId: myUserId,
+                    blockeeId: group.members.first != myUserId
+                        ? group.members.first
+                        : group.members.last,
+                  );
+                }
+              },
+              child: Text('Block'),
+            ),
         ],
       ),
       body: StreamBuilder<List<Message>>(
-        stream:
-            messageRepo.messagesFor(supabase.auth.currentUser!, widget.groupId),
+        stream: messageRepo.messagesFor(supabase.auth.currentUser!, group.id),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             final messages = snapshot.data!;
@@ -114,7 +125,7 @@ class MessagesState extends State<MessagesPage> {
                           },
                         ),
                 ),
-                MessageBar(groupId: widget.groupId),
+                MessageBar(groupId: group.id),
               ],
             );
           } else {
@@ -194,7 +205,7 @@ class _MessageBarState extends State<MessageBar> {
   void _submitMessage(BuildContext context, String toId) async {
     final text = _textController.text;
     final myUserId = supabase.auth.currentUser!.id;
-    log.fine('✅ Group ID: $widget.groupId');
+    log.fine('✅ Group ID: ${widget.groupId}');
     log.fine('✅ To ID: $toId');
     if (text.isEmpty) {
       log.fine('DEBUG: Empty message skipped');
@@ -208,7 +219,10 @@ class _MessageBarState extends State<MessageBar> {
     log.fine("Sent message from:$myUserId, to:$toId: $text");
     try {
       await MessagesRepository().sendMessage(
-          fromProfileId: myUserId, groupId: widget.groupId, text: text);
+        fromProfileId: myUserId,
+        groupId: widget.groupId,
+        text: text,
+      );
       log.fine('Message sent: $text');
     } on Exception catch (error) {
       log.warning("ERROR: $error");


### PR DESCRIPTION
for #343 

This adds the following:
- adding the necessary logic and ui changes to re-prompt user for password before running a sensitive action
- adds an icon in the chat page (temporary ui choice for convenience while the feature is wip) that is guarded by the re-authentication flow and would result in a database record for the blocking.
- added a database table `blocks`

How to test
- login with a user
- open a chat with one person (group chats with more than one person won't support this feature)
- click the block button
- re-authenticate and confirm
- verify a record was added to the `blocks` table in the db

note that the block record doesn't result in other changes in the ui yet, introducing that in a future PR to avoid making a mega PR and/or merge nightmares (this feature is requiring lots of refactoring in how we pipe chats around and will start to involve even more parts of the app and/or existing features as we go)